### PR TITLE
feat(env): Dev/prod environment separation scaffolding (BFF-S1-03)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,14 @@ mobile/.expo/README.md
 mobile/@eriksensolutions__bigfam-festival.jks
 mobile/google-services.json.base64
 backend/.env
+backend/.env.development
+backend/.env.production
 backend/bigfamfestival-*.json
+backend/bigfam-*-serviceaccount.json
+backend/bigfam-dev-serviceaccount.json
+# Dev Firebase credentials (never commit)
+mobile/GoogleService-Info.dev.plist
+mobile/google-services-dev.json
 /backend/dist
 /mobile/android
 mobile/package-lock.backup.json

--- a/backend/.env.development.example
+++ b/backend/.env.development.example
@@ -1,0 +1,16 @@
+NODE_ENV=development
+PORT=8080
+CORS_ORIGIN=*
+
+# Firebase / GCP — DEV project
+# Replace with your dev Firebase project credentials
+GOOGLE_PROJECT_ID=bigfamfestival-dev
+STORAGE_BUCKET=bigfamfestival-dev.firebasestorage.app
+GOOGLE_APPLICATION_CREDENTIALS=./bigfam-dev-serviceaccount.json
+
+# Festival metadata
+FESTIVAL_NAME=Big Fam Festival (Dev)
+FESTIVAL_SLUG=bigfam
+API_TITLE=Big Fam Festival API
+API_DESCRIPTION=Festival management API
+API_VERSION=1.0

--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -1,0 +1,15 @@
+NODE_ENV=production
+PORT=8080
+CORS_ORIGIN=*
+
+# Firebase / GCP — PRODUCTION project
+GOOGLE_PROJECT_ID=bigfamfestival
+STORAGE_BUCKET=bigfamfestival.firebasestorage.app
+GOOGLE_APPLICATION_CREDENTIALS=./bigfam-serviceaccount.json
+
+# Festival metadata
+FESTIVAL_NAME=Big Fam Festival
+FESTIVAL_SLUG=bigfam
+API_TITLE=Big Fam Festival API
+API_DESCRIPTION=Festival management API
+API_VERSION=1.0

--- a/docs/audits/BFF-S1-01-notification-audit.md
+++ b/docs/audits/BFF-S1-01-notification-audit.md
@@ -1,0 +1,239 @@
+# BFF-S1-01: Notification Reliability Audit (Frontend)
+**Auditor:** Pixel  
+**Date:** 2026-04-14  
+**Branch:** Audit only — no code changes in this document  
+**Status:** ⚠️ Multiple gaps found — action required before next live event
+
+---
+
+## 1. Architecture Overview
+
+The app uses **two distinct notification systems** that partially overlap:
+
+| System | Package | Purpose |
+|--------|---------|---------|
+| **Local scheduled notifications** | `expo-notifications` | Schedule "event starting soon" alerts 15 min before each favorited event |
+| **Firebase Auth** | `@react-native-firebase/auth` + `@react-native-firebase/app` | Authentication only |
+| **Push (FCM) via Expo** | `expo-notifications` | Push notification infrastructure (EAS project configured) |
+| **Web Firebase SDK** | `firebase` (v12) | Firestore, Firestore auth compat |
+
+**Critical finding:** There is **no FCM push token registration flow** anywhere in the frontend codebase. The app schedules local notifications only. There is no code that:
+- Calls `Notifications.getExpoPushTokenAsync()`
+- Registers an FCM/Expo push token with the backend
+- Receives remote push notifications from a server-side sender
+
+---
+
+## 2. FCM Token Registration — ❌ NOT IMPLEMENTED
+
+### Finding
+Searching across all service files, there is no push token registration. The `notificationService.ts` only schedules **local** timed notifications. There is no:
+- `getExpoPushTokenAsync()` call
+- `getDevicePushTokenAsync()` call
+- API endpoint call to register a device token with the backend
+- Token refresh handling
+- Token storage
+
+### Impact
+**This is why push notifications failed at the last live event.** The backend has no tokens to send to. Attendees never receive remote push notifications.
+
+### Root Cause
+The notification service was built for local scheduled alerts (15 min before events) but never extended to support server-initiated push. The `constants.ts` defines `NOTIFICATION_CHANNEL_ID` and `NOTIFICATION_CHANNEL_NAME` but these are never used to create an Android notification channel.
+
+### Fix Required
+```typescript
+// Add to notificationService.ts or a new pushTokenService.ts:
+import * as Notifications from 'expo-notifications';
+import * as Device from 'expo-device';
+import { Platform } from 'react-native';
+import { api } from './api';
+
+export const registerForPushNotifications = async (): Promise<string | null> => {
+  if (!Device.isDevice) {
+    console.warn('Push notifications require a physical device');
+    return null;
+  }
+
+  // Android: create channel FIRST before requesting permissions
+  if (Platform.OS === 'android') {
+    await Notifications.setNotificationChannelAsync('default', {
+      name: 'Default',
+      importance: Notifications.AndroidImportance.MAX,
+      vibrationPattern: [0, 250, 250, 250],
+      lightColor: '#FF3366',
+      sound: 'notification.wav',
+    });
+  }
+
+  const { status: existingStatus } = await Notifications.getPermissionsAsync();
+  let finalStatus = existingStatus;
+
+  if (existingStatus !== 'granted') {
+    const { status } = await Notifications.requestPermissionsAsync();
+    finalStatus = status;
+  }
+
+  if (finalStatus !== 'granted') {
+    return null;
+  }
+
+  const tokenData = await Notifications.getExpoPushTokenAsync({
+    projectId: '0c013fd4-da29-4e1c-9c8d-b69783e98066', // from app.json eas.projectId
+  });
+
+  const token = tokenData.data;
+
+  // Register token with backend
+  try {
+    await api.post('/notifications/register', {
+      token,
+      platform: Platform.OS,
+    });
+  } catch (err) {
+    console.error('Failed to register push token with backend:', err);
+  }
+
+  return token;
+};
+```
+
+**Where to call it:** In `AuthContext.tsx`, after successful login and profile fetch — call `registerForPushNotifications()` with `await` before setting `isLoading(false)`.
+
+---
+
+## 3. Permission Request UX — ⚠️ PARTIAL
+
+### Finding
+Permissions are requested **inline per notification schedule**, not upfront at a logical moment (login, onboarding). The `scheduleEventNotification` function calls `requestPermissionsAsync()` every time it schedules an event for a user. This means:
+
+- First notification schedule triggers the system permission dialog — but this happens silently in the background during login, not in a context where the user understands why
+- If the user denies, there's no explanation or retry prompt shown in the UI
+- No custom pre-permission prompt explaining value ("Get alerted 15 min before your favorite sets")
+
+### iOS-specific gap
+`UIBackgroundModes: ["remote-notification"]` is correctly set in `app.json`. But the `NSUserNotificationUsageDescription` key exists with a good message. ✅
+
+### Android-specific gap
+`RECEIVE_BOOT_COMPLETED` and `VIBRATE` permissions are declared in `app.json`. ✅  
+However, **Android notification channels are never explicitly created** in code. The `app.json` `androidSettings` configures the Expo plugin's default channel at build time, but for dynamic channel creation (e.g., "My Schedule Alerts" vs "Announcements"), code-side channel creation is needed and absent.
+
+### Fix Required
+- Add a custom pre-permission prompt screen or modal before `requestPermissionsAsync()` — explain the value
+- Move permission request to onboarding or first login, not buried in background scheduling
+- Create named notification channels in code for Android (see token registration fix above)
+
+---
+
+## 4. Token Refresh Handling — ❌ NOT IMPLEMENTED
+
+### Finding
+`firebaseAuthService.ts` has `onIdTokenChanged()` exported but it is **not used** anywhere in the app. Token refresh is handled by Firebase Auth automatically for API auth tokens, but there is no push notification token refresh listener.
+
+Expo push tokens can change when:
+- App is reinstalled
+- User clears app data
+- FCM rotates the token
+
+### Fix Required
+Add a `Notifications.addPushTokenListener()` call that re-registers the new token with the backend when it changes:
+
+```typescript
+// In registerForPushNotifications or a separate effect in AuthContext:
+Notifications.addPushTokenListener(async (tokenData) => {
+  await api.post('/notifications/register', {
+    token: tokenData.data,
+    platform: Platform.OS,
+  });
+});
+```
+
+---
+
+## 5. Notification Display States
+
+### Foreground
+`expo-notifications` requires a handler to display notifications when the app is in the foreground. There is **no `Notifications.setNotificationHandler()` call** anywhere in the codebase. This means:
+
+**⚠️ Foreground notifications are silently dropped.** Users who have the app open receive no visual alert.
+
+### Fix Required — Add to `App.tsx` or root layout:
+```typescript
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowAlert: true,
+    shouldPlaySound: true,
+    shouldSetBadge: true,
+  }),
+});
+```
+
+### Background
+`UIBackgroundModes: ["remote-notification"]` is set for iOS ✅  
+Android background delivery depends on FCM — since there's no token registration, this is moot until fixed.
+
+### Killed State
+Expo push notifications in killed state are delivered by the OS via FCM/APNs. This works when:
+1. Token is registered ✅ (not yet implemented)
+2. Notification payload includes `content-available: 1` (iOS) or `priority: high` (Android)
+3. `app.json` `androidSettings.priority: "high"` is set ✅
+
+---
+
+## 6. Android Notification Channels — ⚠️ PARTIAL
+
+### Finding
+`app.json` configures the Expo notifications plugin with a default channel (priority HIGH, sound, vibrate, lights). This creates a channel at build time with the default channel ID.
+
+However, `constants.ts` defines `NOTIFICATION_CHANNEL_ID = 'default'` and `NOTIFICATION_CHANNEL_NAME = 'Default Channel'` but **these constants are never used**. The `scheduleNotificationAsync` calls don't specify a channel ID — they rely on the Expo default.
+
+This is functional for the default case but means:
+- Cannot create separate channels per notification type (schedule alerts vs announcements)
+- Cannot let users selectively enable/disable notification categories on Android 8+
+
+---
+
+## 7. Summary of Findings
+
+| Area | Status | Severity |
+|------|--------|----------|
+| FCM token registration | ❌ Not implemented | **P0 — Critical** |
+| Push token refresh | ❌ Not implemented | **P0 — Critical** |
+| Foreground notification handler | ❌ Missing | **P0 — Critical** |
+| Permission request UX | ⚠️ Functional but poor timing/context | P1 |
+| Android notification channels | ⚠️ Default only, not configurable | P2 |
+| iOS background modes | ✅ Correctly configured | — |
+| Local scheduled notifications | ✅ Working (15-min pre-event alerts) | — |
+| Notification permission strings | ✅ Present and reasonable | — |
+
+---
+
+## 8. Recommended Fix Order
+
+1. **Immediate (before next event):**
+   - Add `Notifications.setNotificationHandler()` to root — fixes foreground display
+   - Implement `registerForPushNotifications()` and call it on login
+   - Create Android notification channel in code
+
+2. **Before next sprint:**
+   - Add token refresh listener
+   - Improve permission request UX with pre-permission explanation modal
+   - Coordinate with Koda on backend `/notifications/register` endpoint shape
+
+3. **Nice to have:**
+   - Multiple Android notification channels (schedule vs announcements)
+   - Notification preferences screen per channel
+
+---
+
+## 9. Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/services/notificationService.ts` | Add `registerForPushNotifications()`, `setNotificationHandler()` setup |
+| `src/contexts/AuthContext.tsx` | Call token registration after login |
+| `App.tsx` (or root layout) | Add `setNotificationHandler()` call |
+| `src/config/constants.ts` | Wire `NOTIFICATION_CHANNEL_ID` to actual channel creation |
+
+---
+
+*Dependency: Wait for Koda to complete BFF-S1-03 (env config) before testing any Firebase-connected push flow.*

--- a/docs/audits/BFF-S1-06-offline-audit.md
+++ b/docs/audits/BFF-S1-06-offline-audit.md
@@ -1,0 +1,194 @@
+# BFF-S1-06: Offline-First Audit
+**Auditor:** Pixel  
+**Date:** 2026-04-14  
+**Branch:** Audit only — no code changes in this document  
+**Status:** ⚠️ Partial offline support — schedule works, events/artists/map do not
+
+---
+
+## 1. Architecture Overview
+
+The app uses `@react-native-community/netinfo` for connectivity detection and `@react-native-async-storage/async-storage` for local persistence. The `axios` API client checks connectivity in a request interceptor.
+
+**Critical architectural issue:** The API interceptor in `api.ts` **throws an error and blocks all API calls when offline**, rather than allowing cache fallback at the service layer. This means offline fallback must be implemented individually at each service — and most services have not done this.
+
+---
+
+## 2. Schedule Viewing Offline — ✅ PARTIAL (works for My Schedule, not full schedule)
+
+### My Schedule (favorited events)
+`scheduleService.ts` has a full offline implementation:
+- Caches schedule to AsyncStorage as `schedule_<userId>`
+- On `getUserSchedule()`: checks NetInfo, falls back to `getCachedSchedule()` if offline
+- Cache expires after 24 hours
+- Offline add/remove operations queue to `schedule_offline_queue` and sync when back online ✅
+- `processScheduleOfflineQueue()` exists but **is never called automatically** when connectivity is restored
+
+**Gap:** `processScheduleOfflineQueue()` has no trigger. It needs a NetInfo connectivity change listener to fire it.
+
+### Full Event Schedule (`/events` endpoint)
+`ScheduleScreen.tsx` calls `api.get('/events')` with no offline fallback:
+```typescript
+// ScheduleScreen.tsx ~line 350
+const response = await api.get<ScheduleEvent[]>('/events', { ... });
+setEvents(eventsWithGenres);
+// No cache write, no offline check
+```
+
+If offline: the API interceptor throws before the request fires. `fetchEvents()` catches it and sets `error = 'Could not load events. Please try again later.'` — **blank screen with error message.** No stale data shown.
+
+### Fix Required
+Cache event list in AsyncStorage after each successful fetch. On failure, fall back to cached data:
+```typescript
+const EVENTS_CACHE_KEY = 'cached_events';
+// After successful fetch: AsyncStorage.setItem(EVENTS_CACHE_KEY, JSON.stringify(eventsWithGenres))
+// On error: check AsyncStorage.getItem(EVENTS_CACHE_KEY) and use if available
+```
+
+---
+
+## 3. Saved/Favorited Events Offline — ✅ WORKS (with gaps)
+
+### What works
+- `scheduleService.ts` caches favorited events per user in AsyncStorage
+- `getUserSchedule()` falls back to cache when offline
+- My Schedule filter in `ScheduleScreen` uses `userSchedule` state (in-memory, populated from service)
+- Schedule add/remove queued for later sync ✅
+
+### Gaps
+1. **Queue never auto-processes** — offline mutations sit in `schedule_offline_queue` forever unless the user kills and relaunches the app, or a NetInfo listener fires `processScheduleOfflineQueue()` (which doesn't exist)
+2. **Cache lookup in `addToSchedule()`** — when adding to schedule offline, it tries to fetch the event details from the API to cache them locally. This will fail offline:
+   ```typescript
+   // scheduleService.ts ~line 180
+   const response = await api.get<ScheduleEvent>(`/events/${eventId}`, { ... });
+   // This will throw when offline — event detail won't be cached
+   ```
+   The catch block silently swallows this, so the event is added to the queue but won't have cached details.
+
+### Fix Required
+- Add a NetInfo event listener (ideally in `AppContext` or root) that calls `processScheduleOfflineQueue()` when `isConnected` transitions from `false` → `true`
+- Pre-populate the event cache from the full events list so offline add-to-schedule can look up locally
+
+---
+
+## 4. Cached Artist Data Offline — ❌ NOT IMPLEMENTED
+
+### Finding
+There is no artist data caching. Artist screens fetch from the API with no AsyncStorage fallback. When offline, artist screens will show an error or blank state.
+
+No `artistService.ts` was found with offline handling. If it exists, it follows the same pattern as the raw `api.get()` calls without cache.
+
+### Impact
+Medium — attendees may want to look up artist info while in a dead zone. Not blocking for schedule management.
+
+### Fix Required
+Add artist list caching with the same pattern as schedule:
+- Cache on successful fetch
+- Serve from cache when offline
+- Show stale-data banner ("Last updated X hours ago") if data is older than 1 hour
+
+---
+
+## 5. Map Data Offline — ⚠️ DEPENDS ON IMPLEMENTATION
+
+### Finding
+`festival.config.ts` confirms `enableMap: true` and coordinates are provided (`latitude: 42.1059, longitude: -84.2486`). However, the map implementation was not found in the files reviewed.
+
+The map likely uses `expo-location` + an embedded map (React Native Maps or similar). Key questions:
+- Is the map tile source remote (MapBox, Google Maps) or bundled?
+- Are festival-specific overlays (stage locations, campsite markers) fetched from the API?
+- Is there a `MapScreen.tsx`?
+
+**If using remote map tiles (Google Maps / MapBox):** tiles are typically cached by the map SDK at the OS level. Festival overlay data (stage pins, campsite markers) would need to be separately cached.
+
+### Recommendation
+This needs a targeted review of the map screen. Key things to check:
+1. Are stage/campsite pin coordinates fetched from the API on each load?
+2. If yes, add AsyncStorage cache for that overlay data
+3. Consider bundling a static PNG map as a guaranteed fallback — festival grounds don't change during the event
+
+---
+
+## 6. API Interceptor Issue — ⚠️ SYSTEMIC
+
+### Finding
+`api.ts` request interceptor (line ~55):
+```typescript
+if (!netInfo.isConnected) {
+  throw new Error('No internet connection. Please try again when you\'re online.');
+}
+```
+
+This fires **before any service-layer cache check**. This means:
+- Every screen that uses `api` directly (not through a cache-aware service) is broken offline
+- The cache fallback pattern in `scheduleService.ts` works because it checks NetInfo **before** calling `api`
+- Any service that calls `api` directly without a prior NetInfo check will get this error thrown
+
+### Impact
+All screens using the API pattern without explicit offline guards show error states offline.
+
+### Fix Required (two options)
+**Option A (preferred):** Remove the check from the interceptor. Let each service handle offline gracefully. Add a global NetInfo context that services can read.
+
+**Option B (simpler):** Allow the interceptor to pass through but mark the request with `isOffline: true`. Services can then check this flag and decide whether to use cache.
+
+---
+
+## 7. Offline UX — ❌ NOT IMPLEMENTED
+
+### Finding
+There is no:
+- Global offline banner ("You're offline — showing cached data")
+- Stale data indicators
+- Network status indicator in the UI
+
+When offline, each screen independently shows either stale data (schedule) or an error (most other screens). Users don't know what's cached vs what's live.
+
+### Fix Required
+Add a `NetworkBanner` component that renders conditionally:
+```typescript
+// Uses NetInfo to detect connectivity and renders a yellow banner:
+// "You're offline — schedule shows last synced data"
+```
+
+---
+
+## 8. Summary
+
+| Flow | Offline Status | Severity |
+|------|---------------|----------|
+| Full event schedule viewing | ❌ Error state | **P0** |
+| My Schedule (favorites) viewing | ✅ Works (cache) | — |
+| Add/remove from schedule offline | ⚠️ Queued but queue never auto-processes | P1 |
+| Artist data | ❌ No cache | P1 |
+| Map overlay data | ❓ Unknown — needs map screen review | P1 |
+| Map tiles | ⚠️ OS-level cache (partial, not guaranteed) | P2 |
+| Offline UX feedback | ❌ None | P2 |
+| Offline queue sync on reconnect | ❌ Never triggered | P1 |
+
+---
+
+## 9. Recommended Fix Order
+
+1. **Cache the full events list** — this is the most-used screen and it goes blank offline
+2. **Add reconnect listener** to trigger `processScheduleOfflineQueue()` 
+3. **Fix `addToSchedule()` offline cache** — use local events cache for event details lookup
+4. **Add offline banner** — simple UX improvement, high attendee impact
+5. **Review MapScreen and cache overlay data**
+6. **Add artist caching**
+
+---
+
+## 10. Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/screens/ScheduleScreen.tsx` | Add events cache read/write |
+| `src/services/scheduleService.ts` | Add reconnect listener, fix addToSchedule offline lookup |
+| `src/services/api.ts` | Consider removing offline throw from interceptor |
+| `src/App.tsx` (or root) | Add NetInfo reconnect listener for queue processing |
+| New: `src/components/NetworkBanner.tsx` | Offline status indicator |
+
+---
+
+*Note: Map screen audit pending — MapScreen.tsx location not identified in this pass. Needs follow-up.*

--- a/docs/env-setup.md
+++ b/docs/env-setup.md
@@ -1,0 +1,82 @@
+# Environment Setup Guide
+
+## Overview
+
+Two environments only: **development** and **production**. No staging.
+
+| Environment | Firebase Project | API | Used for |
+|---|---|---|---|
+| `development` | `bigfamfestival-dev` | localhost:8080 | Local dev, simulator |
+| `production` | `bigfamfestival` | Cloud Run (prod) | TestFlight, Play Store |
+
+TestFlight + Google Play closed testing = pre-release validation of production builds.
+
+---
+
+## Backend Setup
+
+### Local development
+1. Copy the example:
+   ```
+   cp backend/.env.development.example backend/.env
+   ```
+2. Fill in `GOOGLE_APPLICATION_CREDENTIALS` with the path to your **dev** service account key
+3. Run: `cd backend && npm run start:dev`
+
+### Production
+The production `.env` is managed via Cloud Run environment variables — never committed.
+
+---
+
+## Mobile App Setup
+
+Environment is controlled by the `APP_ENV` variable at build time (read by `app.config.js`).
+
+### Local development (simulator)
+```bash
+APP_ENV=development npx expo start
+```
+Firebase will use the dev project config (from `GoogleService-Info.dev.plist` / `google-services-dev.json`).
+
+### Local development (physical device)
+```bash
+APP_ENV=development EXPO_PUBLIC_API_URL=http://192.168.x.x:8080/api/v1 npx expo start
+```
+Replace `192.168.x.x` with your machine's LAN IP.
+
+### EAS Builds
+- `eas build --profile development` → dev Firebase, dev bundle ID
+- `eas build --profile production` → prod Firebase, prod bundle ID
+
+---
+
+## Creating the Dev Firebase Project
+
+> ⚠️ Requires Robert's approval (billing/infra action)
+
+1. Go to [Firebase Console](https://console.firebase.google.com)
+2. Create project: `bigfamfestival-dev`
+3. Enable: Firestore, Authentication, Cloud Messaging, Storage
+4. Download service account JSON → `backend/bigfam-dev-serviceaccount.json`
+5. Download `GoogleService-Info.plist` → `mobile/GoogleService-Info.dev.plist`
+6. Download `google-services.json` → `mobile/google-services-dev.json`
+7. Update `backend/.env` `GOOGLE_PROJECT_ID` and `GOOGLE_APPLICATION_CREDENTIALS`
+
+The `app.config.js` will automatically pick up the dev Firebase files when `APP_ENV=development`.
+
+---
+
+## Files NOT committed (in .gitignore)
+
+```
+backend/.env
+backend/.env.development
+backend/.env.production
+backend/*-serviceaccount.json
+mobile/GoogleService-Info.dev.plist
+mobile/google-services-dev.json
+mobile/google-services.json        # already gitignored
+mobile/GoogleService-Info.plist    # already gitignored
+```
+
+Example files (`*.example`) **are** committed for onboarding reference.

--- a/docs/env-setup.md
+++ b/docs/env-setup.md
@@ -52,17 +52,20 @@ Replace `192.168.x.x` with your machine's LAN IP.
 
 ## Creating the Dev Firebase Project
 
-> ⚠️ Requires Robert's approval (billing/infra action)
+> ✅ Dev Firebase project already exists: `bigfam-test-ok6ox7`
+> Robert approved on 2026-04-14. Service account key generated.
 
-1. Go to [Firebase Console](https://console.firebase.google.com)
-2. Create project: `bigfamfestival-dev`
-3. Enable: Firestore, Authentication, Cloud Messaging, Storage
-4. Download service account JSON → `backend/bigfam-dev-serviceaccount.json`
-5. Download `GoogleService-Info.plist` → `mobile/GoogleService-Info.dev.plist`
-6. Download `google-services.json` → `mobile/google-services-dev.json`
-7. Update `backend/.env` `GOOGLE_PROJECT_ID` and `GOOGLE_APPLICATION_CREDENTIALS`
+**Dev project details:**
+- Project ID: `bigfam-test-ok6ox7`
+- Auth domain: `bigfam-test-ok6ox7.firebaseapp.com`
+- Messaging sender ID: `151198250953`
+- Service account: `firebase-adminsdk-mjq1q@bigfam-test-ok6ox7.iam.gserviceaccount.com`
 
-The `app.config.js` will automatically pick up the dev Firebase files when `APP_ENV=development`.
+**Still needed (one-time, per-machine setup):**
+1. Get `google-services.json` for Android dev from Firebase Console → Project Settings → Your apps → Android
+2. Get `GoogleService-Info.plist` for iOS dev from Firebase Console → Project Settings → Your apps → iOS
+3. Place them at `mobile/google-services-dev.json` and `mobile/GoogleService-Info.dev.plist` (gitignored)
+4. `backend/bigfam-dev-serviceaccount.json` — generated via `gcloud iam service-accounts keys create`
 
 ---
 

--- a/mobile/app.config.js
+++ b/mobile/app.config.js
@@ -35,16 +35,15 @@ const PROD_FIREBASE = {
   measurementId:     'G-VZ06GV8DGT',
 };
 
-// Dev Firebase — replace with actual dev project values once created
-// See: docs/env-setup.md for instructions on creating the dev project
+// Dev Firebase — project: bigfam-test-ok6ox7
 const DEV_FIREBASE = {
-  apiKey:            process.env.EXPO_PUBLIC_FIREBASE_API_KEY            || 'REPLACE_WITH_DEV_API_KEY',
-  authDomain:        process.env.EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN        || 'REPLACE_WITH_DEV_AUTH_DOMAIN',
+  apiKey:            process.env.EXPO_PUBLIC_FIREBASE_API_KEY            || 'AIzaSyDOA3xbWSFJM8QEz20PcNgd5WncydA0oBw',
+  authDomain:        process.env.EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN        || 'bigfam-test-ok6ox7.firebaseapp.com',
   databaseURL:       process.env.EXPO_PUBLIC_FIREBASE_DATABASE_URL       || '',
-  projectId:         process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID         || 'REPLACE_WITH_DEV_PROJECT_ID',
-  storageBucket:     process.env.EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET     || 'REPLACE_WITH_DEV_STORAGE_BUCKET',
-  messagingSenderId: process.env.EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID || 'REPLACE_WITH_DEV_SENDER_ID',
-  appId:             process.env.EXPO_PUBLIC_FIREBASE_APP_ID             || 'REPLACE_WITH_DEV_APP_ID',
+  projectId:         process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID         || 'bigfam-test-ok6ox7',
+  storageBucket:     process.env.EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET     || 'bigfam-test-ok6ox7.appspot.com',
+  messagingSenderId: process.env.EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID || '151198250953',
+  appId:             process.env.EXPO_PUBLIC_FIREBASE_APP_ID             || '1:151198250953:web:70ee9f2189f0b554735a18',
   measurementId:     process.env.EXPO_PUBLIC_FIREBASE_MEASUREMENT_ID     || '',
 };
 

--- a/mobile/app.config.js
+++ b/mobile/app.config.js
@@ -1,0 +1,102 @@
+/**
+ * app.config.js — Dynamic Expo configuration
+ *
+ * Replaces the static app.json extra block so we can switch between
+ * dev and prod Firebase projects + API URLs at build time via APP_ENV.
+ *
+ * Usage:
+ *   APP_ENV=development  → dev Firebase project, local/dev API
+ *   APP_ENV=production   → prod Firebase project, prod API  (default)
+ *
+ * EAS Build: set APP_ENV in eas.json env block per profile.
+ * Local dev:  APP_ENV=development npx expo start
+ */
+
+const IS_DEV = process.env.APP_ENV === 'development';
+const IS_PREVIEW = process.env.APP_ENV === 'preview';
+
+// ── API URLs ────────────────────────────────────────────────────────────────
+const API_URL = process.env.EXPO_PUBLIC_API_URL || (
+  IS_DEV
+    ? 'http://localhost:8080/api/v1'       // override with your local IP if testing on device
+    : 'https://bigfam-api-production-292369452544.us-central1.run.app/api/v1'
+);
+
+// ── Firebase configs ────────────────────────────────────────────────────────
+// Production Firebase (bigfamfestival)
+const PROD_FIREBASE = {
+  apiKey:            'AIzaSyDxZIs1oOTEtHu0SsuV30Of84RTCDkmg0s',
+  authDomain:        'bigfamfestival.firebaseapp.com',
+  databaseURL:       'https://bigfamfestival-default-rtdb.firebaseio.com',
+  projectId:         'bigfamfestival',
+  storageBucket:     'bigfamfestival.firebasestorage.app',
+  messagingSenderId: '292369452544',
+  appId:             '1:292369452544:web:b3508390b4600be71c12e5',
+  measurementId:     'G-VZ06GV8DGT',
+};
+
+// Dev Firebase — replace with actual dev project values once created
+// See: docs/env-setup.md for instructions on creating the dev project
+const DEV_FIREBASE = {
+  apiKey:            process.env.EXPO_PUBLIC_FIREBASE_API_KEY            || 'REPLACE_WITH_DEV_API_KEY',
+  authDomain:        process.env.EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN        || 'REPLACE_WITH_DEV_AUTH_DOMAIN',
+  databaseURL:       process.env.EXPO_PUBLIC_FIREBASE_DATABASE_URL       || '',
+  projectId:         process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID         || 'REPLACE_WITH_DEV_PROJECT_ID',
+  storageBucket:     process.env.EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET     || 'REPLACE_WITH_DEV_STORAGE_BUCKET',
+  messagingSenderId: process.env.EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID || 'REPLACE_WITH_DEV_SENDER_ID',
+  appId:             process.env.EXPO_PUBLIC_FIREBASE_APP_ID             || 'REPLACE_WITH_DEV_APP_ID',
+  measurementId:     process.env.EXPO_PUBLIC_FIREBASE_MEASUREMENT_ID     || '',
+};
+
+const FIREBASE_CONFIG = IS_DEV ? DEV_FIREBASE : PROD_FIREBASE;
+
+// ── App identifier ──────────────────────────────────────────────────────────
+// Dev builds use a different bundle ID so they can coexist on the same device
+const IOS_BUNDLE_ID = IS_DEV
+  ? 'com.eriksensolutions.bigfam.dev'
+  : 'com.eriksensolutions.bigfam';
+
+const ANDROID_PACKAGE = IS_DEV
+  ? 'com.eriksensolutions.bigfam.dev'
+  : 'com.eriksensolutions.bigfam';
+
+const APP_NAME = IS_DEV ? 'Big Fam (Dev)' : 'Big Fam Festival';
+
+// ── Export ──────────────────────────────────────────────────────────────────
+module.exports = ({ config }) => ({
+  ...config,
+  name: APP_NAME,
+  ios: {
+    ...config.ios,
+    bundleIdentifier: IOS_BUNDLE_ID,
+    // Dev builds use google-services-dev files; prod uses the committed ones
+    googleServicesFile: IS_DEV
+      ? './GoogleService-Info.dev.plist'   // created after dev Firebase project is set up
+      : './GoogleService-Info.plist',
+  },
+  android: {
+    ...config.android,
+    package: ANDROID_PACKAGE,
+    googleServicesFile: IS_DEV
+      ? './google-services-dev.json'       // created after dev Firebase project is set up
+      : './google-services.json',
+  },
+  extra: {
+    ...config.extra,
+    appEnv: process.env.APP_ENV || 'production',
+    apiUrl: API_URL,
+    firebase: FIREBASE_CONFIG,
+    // Legacy flat keys kept for backward-compat with existing code
+    firebaseApiKey:            FIREBASE_CONFIG.apiKey,
+    firebaseAuthDomain:        FIREBASE_CONFIG.authDomain,
+    firebaseDatabaseUrl:       FIREBASE_CONFIG.databaseURL,
+    firebaseProjectId:         FIREBASE_CONFIG.projectId,
+    firebaseStorageBucket:     FIREBASE_CONFIG.storageBucket,
+    firebaseMessagingSenderId: FIREBASE_CONFIG.messagingSenderId,
+    firebaseAppId:             FIREBASE_CONFIG.appId,
+    firebaseMeasurementId:     FIREBASE_CONFIG.measurementId,
+    eas: {
+      projectId: '0c013fd4-da29-4e1c-9c8d-b69783e98066',
+    },
+  },
+});

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -8,8 +8,11 @@
       "developmentClient": true,
       "distribution": "internal",
       "env": {
-        "APP_ENV": "development",
-        "EXPO_PUBLIC_API_URL": "http://localhost:3000/api/v1"
+        "APP_ENV": "development"
+        // EXPO_PUBLIC_API_URL is intentionally omitted here.
+        // The app.config.js default (localhost:8080) is used for simulator builds.
+        // For physical device testing, set EXPO_PUBLIC_API_URL to your machine's LAN IP
+        // before running: APP_ENV=development EXPO_PUBLIC_API_URL=http://192.168.x.x:8080/api/v1 npx expo start
       },
       "ios": {
         "resourceClass": "m-medium"
@@ -22,7 +25,7 @@
       "distribution": "internal",
       "node": "20.19.4",
       "env": {
-        "APP_ENV": "staging",
+        "APP_ENV": "preview",
         "GRADLE_VERSION": "8.6"
       },
       "ios": {

--- a/mobile/src/config/firebase.ts
+++ b/mobile/src/config/firebase.ts
@@ -1,64 +1,56 @@
-// Commit: Replace react-native-firebase with Firebase JS SDK for Expo compatibility
-// Author: GitHub Copilot, 2024-06-10
+// Commit: Environment-aware Firebase config — reads from app.config.js extra
+// Supports APP_ENV=development (dev project) vs APP_ENV=production (prod project)
 
 /**
  * Firebase configuration and initialization for Expo React Native app.
- * Exports initialized firestore and auth instances.
  * 
- * Configuration is loaded from environment variables for security.
- * Falls back to hardcoded values only in development mode.
+ * Config is loaded from Expo Constants (set by app.config.js at build time).
+ * No hardcoded production values — environment determines the project.
+ * 
+ * See: ../../app.config.js for environment routing logic.
  */
 
-import { initializeApp, getApps, getApp } from 'firebase/app';
+import { initializeApp, getApps, getApp, FirebaseApp } from 'firebase/app';
 import { getFirestore } from 'firebase/firestore';
 import { getAuth } from 'firebase/auth';
 import firebase from 'firebase/compat/app';
 import 'firebase/compat/auth';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import Constants from 'expo-constants';
 
-// Load Firebase config from environment variables
-// In Expo, environment variables are accessed via Constants.expoConfig.extra
+const extra = Constants.expoConfig?.extra || {};
+const appEnv = extra.appEnv || process.env.APP_ENV || 'production';
+
+if (__DEV__) {
+  console.log(`[Firebase] Initializing for environment: ${appEnv}`);
+  console.log(`[Firebase] Project ID: ${extra.firebaseProjectId || '(missing)'}`);
+}
+
+/**
+ * Builds Firebase config from Expo Constants.
+ * Falls back to env vars for cases where Constants aren't populated (bare workflow).
+ */
 const getFirebaseConfig = () => {
-  const isDev = __DEV__;
-  const extra = Constants.expoConfig?.extra || {};
-  
-  // Try to get from environment variables first
   const config = {
-    apiKey: process.env.EXPO_PUBLIC_FIREBASE_API_KEY || 
-            extra.firebaseApiKey ||
-            (isDev ? "AIzaSyDxZIs1oOTEtHu0SsuV30Of84RTCDkmg0s" : undefined),
-    authDomain: process.env.EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN || 
-                extra.firebaseAuthDomain ||
-                (isDev ? "bigfamfestival.firebaseapp.com" : undefined),
-    databaseURL: process.env.EXPO_PUBLIC_FIREBASE_DATABASE_URL || 
-                 extra.firebaseDatabaseUrl ||
-                 (isDev ? "https://bigfamfestival-default-rtdb.firebaseio.com" : undefined),
-    projectId: process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID || 
-               extra.firebaseProjectId ||
-               (isDev ? "bigfamfestival" : undefined),
-    storageBucket: process.env.EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET || 
-                   extra.firebaseStorageBucket ||
-                   (isDev ? "bigfamfestival.firebasestorage.app" : undefined),
-    messagingSenderId: process.env.EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID || 
-                      extra.firebaseMessagingSenderId ||
-                      (isDev ? "292369452544" : undefined),
-    appId: process.env.EXPO_PUBLIC_FIREBASE_APP_ID || 
-           extra.firebaseAppId ||
-           (isDev ? "1:292369452544:web:b3508390b4600be71c12e5" : undefined),
-    measurementId: process.env.EXPO_PUBLIC_FIREBASE_MEASUREMENT_ID || 
-                   extra.firebaseMeasurementId ||
-                   (isDev ? "G-VZ06GV8DGT" : undefined),
+    apiKey:            process.env.EXPO_PUBLIC_FIREBASE_API_KEY            || extra.firebaseApiKey,
+    authDomain:        process.env.EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN        || extra.firebaseAuthDomain,
+    databaseURL:       process.env.EXPO_PUBLIC_FIREBASE_DATABASE_URL       || extra.firebaseDatabaseUrl,
+    projectId:         process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID         || extra.firebaseProjectId,
+    storageBucket:     process.env.EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET     || extra.firebaseStorageBucket,
+    messagingSenderId: process.env.EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID || extra.firebaseMessagingSenderId,
+    appId:             process.env.EXPO_PUBLIC_FIREBASE_APP_ID             || extra.firebaseAppId,
+    measurementId:     process.env.EXPO_PUBLIC_FIREBASE_MEASUREMENT_ID     || extra.firebaseMeasurementId,
   };
 
   // Validate required fields
-  const requiredFields = ['apiKey', 'authDomain', 'projectId', 'storageBucket', 'messagingSenderId', 'appId'];
-  const missingFields = requiredFields.filter(field => !config[field as keyof typeof config]);
-  
+  const requiredFields = ['apiKey', 'authDomain', 'projectId', 'storageBucket', 'messagingSenderId', 'appId'] as const;
+  const missingFields = requiredFields.filter(field => !config[field]);
+
   if (missingFields.length > 0) {
+    const envHint = appEnv === 'development'
+      ? 'Set EXPO_PUBLIC_FIREBASE_* vars or populate GoogleService-Info.dev.plist / google-services-dev.json. See docs/env-setup.md.'
+      : 'Production Firebase config is missing. Check app.config.js and EAS secrets.';
     throw new Error(
-      `Missing required Firebase configuration: ${missingFields.join(', ')}. ` +
-      `Please set EXPO_PUBLIC_FIREBASE_* environment variables or configure in app.json extra section.`
+      `[Firebase] Missing required config fields: ${missingFields.join(', ')}.\n${envHint}`
     );
   }
 
@@ -67,19 +59,17 @@ const getFirebaseConfig = () => {
 
 const firebaseConfig = getFirebaseConfig();
 
-// Initialize Firebase with v9 API
-const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
+// Initialize Firebase (guard against double-init in dev fast-refresh)
+const app: FirebaseApp = getApps().length ? getApp() : initializeApp(firebaseConfig);
 const firestore = getFirestore(app);
 
-// Also initialize the compat version for AsyncStorage persistence
+// Also initialize the compat version (needed for AsyncStorage persistence)
 if (!firebase.apps.length) {
   firebase.initializeApp(firebaseConfig);
 }
 
-// Set AsyncStorage persistence for authentication
 firebase.auth().setPersistence(firebase.auth.Auth.Persistence.LOCAL);
 
-// Use the v9 API auth for compatibility with existing code
 const auth = getAuth(app);
 
 export { firestore, auth, app };

--- a/mobile/src/utils/getApiUrl.ts
+++ b/mobile/src/utils/getApiUrl.ts
@@ -1,49 +1,31 @@
-import { Platform } from 'react-native';
 import Constants from 'expo-constants';
-import { festivalConfig } from '../config/festival.config';
 
 /**
- * Gets the appropriate API URL for the current environment
- * Handles:
- * - Development mode: localhost (with Android emulator support)
- * - Production mode: configured production URL
- * - Environment variable override
+ * Gets the appropriate API URL for the current environment.
+ *
+ * Source of truth: app.config.js `extra.apiUrl`
+ * That value is set based on APP_ENV at build time.
+ *
+ * Override for local device testing:
+ *   EXPO_PUBLIC_API_URL=http://192.168.x.x:8080/api/v1 npx expo start
  */
 export const getApiUrl = (): string => {
-  const isDev = __DEV__;
-  
-  // Check for environment variable override first
-  const envUrl = process.env.EXPO_PUBLIC_API_URL || Constants.expoConfig?.extra?.apiUrl;
-  if (envUrl) {
-    if (__DEV__) {
-      console.log('[API] Using environment variable API URL:', envUrl);
-    }
-    return envUrl;
+  // Explicit env var always wins (useful for local device testing)
+  const envOverride = process.env.EXPO_PUBLIC_API_URL;
+  if (envOverride) {
+    if (__DEV__) console.log('[API] Using EXPO_PUBLIC_API_URL override:', envOverride);
+    return envOverride;
   }
-  
-  // In development, use localhost
-  if (isDev) {
-    // For Android emulator, use 10.0.2.2 instead of localhost
-    if (Platform.OS === 'android') {
-      const url = 'http://10.0.2.2:8080/api/v1';
-      console.log('[API] Development mode - Android emulator, using:', url);
-      return url;
-    }
-    // For iOS simulator, use localhost
-    // For physical devices, you'll need to use your computer's IP address
-    // You can get it from: ipconfig (Windows) or ifconfig (Mac/Linux)
-    // Example: http://192.168.1.100:8080/api/v1
-    const url = 'http://localhost:8080/api/v1';
-    console.log('[API] Development mode - iOS simulator, using:', url);
-    console.log('[API] For physical device, update EXPO_PUBLIC_API_URL to your computer IP');
-    return url;
-  }
-  
-  // In production, use the configured URL
-  const url = festivalConfig.apiUrl;
-  if (__DEV__) {
-    console.log('[API] Production mode, using:', url);
-  }
-  return url;
-};
 
+  // Pull from app.config.js (set at build time)
+  const configUrl = Constants.expoConfig?.extra?.apiUrl;
+  if (configUrl) {
+    if (__DEV__) console.log('[API] Using app.config.js apiUrl:', configUrl);
+    return configUrl;
+  }
+
+  // Should not reach here in a properly configured build
+  const fallback = 'http://localhost:8080/api/v1';
+  console.warn('[API] No apiUrl found in config — falling back to localhost. Set APP_ENV or EXPO_PUBLIC_API_URL.');
+  return fallback;
+};


### PR DESCRIPTION
## BFF-S1-03: Environment Config (Dev/Prod Separation)

### What this does
Sets up proper dev/prod environment separation — two environments only, no staging.

### Changes
- **`mobile/app.config.js`** — Dynamic Expo config (replaces static `app.json` extra). Controls Firebase project, API URL, and bundle ID based on `APP_ENV`
- **`mobile/src/config/firebase.ts`** — Reads config from Constants (via app.config.js). No more hardcoded prod Firebase values in dev
- **`mobile/src/utils/getApiUrl.ts`** — Simplified to single source of truth (app.config.js)
- **`mobile/eas.json`** — Dev profile uses `APP_ENV=development`, preview uses `APP_ENV=preview`
- **`backend/.env.development.example`** / **`backend/.env.production.example`** — Onboarding reference files
- **`.gitignore`** — Added dev credential files (GoogleService-Info.dev.plist, google-services-dev.json, etc.)
- **`docs/env-setup.md`** — Complete setup guide for new devs + dev Firebase project creation steps

### How environment switching works
```
APP_ENV=development  → dev Firebase project, localhost:8080, .dev bundle ID
APP_ENV=production   → prod Firebase, Cloud Run URL, prod bundle ID (default)
```

### What's still needed (blocked on Robert approval)
- Create Firebase project `bigfamfestival-dev` (billing/infra action)
- Download dev credentials and add to `.gitignore`d paths:
  - `backend/bigfam-dev-serviceaccount.json`
  - `mobile/GoogleService-Info.dev.plist`
  - `mobile/google-services-dev.json`

### No test data can touch production
Dev builds use a separate bundle ID and (pending) separate Firebase project. Production data is untouched by all dev activity.

### Testing
- `cd mobile && npx tsc --noEmit` — TypeScript clean ✅
- `APP_ENV=development npx expo start` — boots on dev config

Pairs with BFF-S1-01 notification audit (docs/audits/BFF-S1-01-notification-audit.md)