### PR TITLE
feat(sprint1): BFF-S1-04 error monitoring + BFF-S1-05 API audit fixes

### DIFF
--- a/backend/src/auth/guards/firebase-auth.guard.spec.ts
+++ b/backend/src/auth/guards/firebase-auth.guard.spec.ts
@@ -126,7 +126,7 @@ describe('FirebaseAuthGuard', () => {
 
       await guard.canActivate(context);
 
-      expect(request.user.role).toBe('ATTENDEE');
+      expect(request.user.role).toBe('attendee');
     });
 
     it('should reject expired token with specific error', async () => {

--- a/backend/src/auth/guards/firebase-auth.guard.ts
+++ b/backend/src/auth/guards/firebase-auth.guard.ts
@@ -8,6 +8,7 @@ import {
 import { Reflector } from '@nestjs/core';
 import * as admin from 'firebase-admin';
 import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
+import { Role } from '../enums/role.enum';
 
 /**
  * Guard that validates Firebase ID tokens for authentication.
@@ -48,7 +49,7 @@ export class FirebaseAuthGuard implements CanActivate {
     }
 
     try {
-      const decodedToken = await admin.auth().verifyIdToken(token);
+      const decodedToken = await admin.auth().verifyIdToken(token, true);
 
       // Attach decoded Firebase token info to request
       request.user = {
@@ -56,7 +57,7 @@ export class FirebaseAuthGuard implements CanActivate {
         sub: decodedToken.uid,
         uid: decodedToken.uid,
         email: decodedToken.email,
-        role: decodedToken.role || 'ATTENDEE', // Custom claim for role
+        role: decodedToken.role || Role.ATTENDEE, // Custom claim for role
         emailVerified: decodedToken.email_verified,
         authProvider: 'firebase',
       };


### PR DESCRIPTION
## Summary

Sprint 1 backend tasks: Sentry error monitoring setup and API stability audit with P1/P2 fixes applied.

---

## BFF-S1-04: Error Monitoring (Sentry)

- Install `@sentry/nestjs`, `@sentry/node`, `@sentry/profiling-node`
- `src/config/sentry/sentry.config.ts` — env-aware init, disabled in dev unless DSN set, warns in prod if missing
- Wired into `main.ts` before `NestFactory.create`
- `SENTRY_DSN` added to config schema validation
- Auth headers + health check noise filtered from all Sentry events
- Mobile: `EXPO_PUBLIC_SENTRY_DSN` placeholder added to `eas.json` production profile
- `.env.*.example` files documenting all required env vars

**Operator action required before prod:** Create Sentry projects at sentry.io, set `SENTRY_DSN` on Cloud Run and `EXPO_PUBLIC_SENTRY_DSN` in eas.json.

---

## BFF-S1-05: API Stability Audit — P1/P2 Fixes

Full audit doc: `docs/audits/BFF-S1-05-api-stability-audit.md`
Overall rating: **B+ — ship-ready**

### Fixes in this PR

**P1 — Notification DTO had no validation**
- Extracted inline interface to `notifications/dto/create-notification.dto.ts` with class-validator decorators
- Prevents malformed payloads from reaching Firestore

**P1 — Push token DTO had no validation**
- Added `UpdatePushTokenDto` with `@IsNotEmpty()`
- Prevents null/empty token writes that silently break push delivery

**P2 — Genres error handling**
- Replaced raw `throw new Error()` with `InternalServerErrorException` for proper Sentry context

### Design decisions confirmed
- `GET /schedule/:userId` — intentionally open (social feature, friends can see each other's lineups)
- Role self-promotion fix is in PR #11