### PR TITLE
fix(profile): avatar upload via Firebase Storage direct (BFF-S2-01 + BFF-S2-02)

### DIFF
--- a/mobile/src/config/firebase.ts
+++ b/mobile/src/config/firebase.ts
@@ -13,6 +13,7 @@
 import { initializeApp, getApps, getApp, FirebaseApp } from 'firebase/app';
 import { getFirestore } from 'firebase/firestore';
 import { getAuth } from 'firebase/auth';
+import { getStorage } from 'firebase/storage';
 import firebase from 'firebase/compat/app';
 import 'firebase/compat/auth';
 import Constants from 'expo-constants';
@@ -62,6 +63,7 @@ const firebaseConfig = getFirebaseConfig();
 // Initialize Firebase (guard against double-init in dev fast-refresh)
 const app: FirebaseApp = getApps().length ? getApp() : initializeApp(firebaseConfig);
 const firestore = getFirestore(app);
+const storage = getStorage(app);
 
 // Also initialize the compat version (needed for AsyncStorage persistence)
 if (!firebase.apps.length) {
@@ -72,4 +74,4 @@ firebase.auth().setPersistence(firebase.auth.Auth.Persistence.LOCAL);
 
 const auth = getAuth(app);
 
-export { firestore, auth, app };
+export { firestore, auth, app, storage };

--- a/mobile/src/services/userService.ts
+++ b/mobile/src/services/userService.ts
@@ -44,9 +44,14 @@ export const updateUserProfile = async (
   }
 };
 
+const MAX_AVATAR_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
+const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+
 /**
  * Upload profile picture directly to Firebase Storage, then update user profile with the URL.
  * Does not require a backend upload-url endpoint.
+ *
+ * Validates file size (max 5 MB) and type (jpeg/png/webp) before uploading.
  */
 export const uploadProfilePicture = async (
   userId: string,
@@ -62,9 +67,20 @@ export const uploadProfilePicture = async (
     const response = await fetch(imageUri);
     const blob = await response.blob();
 
+    // Validate file size
+    if (blob.size > MAX_AVATAR_SIZE_BYTES) {
+      throw new Error('Image is too large. Please choose a photo under 5 MB.');
+    }
+
+    // Validate file type
+    const mimeType = blob.type || 'image/jpeg';
+    if (!ALLOWED_IMAGE_TYPES.includes(mimeType)) {
+      throw new Error('Unsupported image format. Please use JPEG, PNG, or WebP.');
+    }
+
     // Upload to Firebase Storage: profile-pictures/<userId>.jpg
     const storageRef = ref(storage, `profile-pictures/${userId}.jpg`);
-    await uploadBytes(storageRef, blob, { contentType: 'image/jpeg' });
+    await uploadBytes(storageRef, blob, { contentType: mimeType });
 
     // Get the public download URL
     const downloadUrl = await getDownloadURL(storageRef);
@@ -76,9 +92,7 @@ export const uploadProfilePicture = async (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
     console.error('Upload profile picture error:', error.message);
-    throw new Error(
-      error.message || 'Failed to upload profile picture'
-    );
+    throw new Error(error.message || 'Failed to upload profile picture');
   }
 };
 

--- a/mobile/src/services/userService.ts
+++ b/mobile/src/services/userService.ts
@@ -1,9 +1,10 @@
 import { api } from './api';
 import { getIdToken } from './firebaseAuthService';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import * as FileSystem from 'expo-file-system';
 import NetInfo from '@react-native-community/netinfo';
 import { User } from '../contexts/AuthContext';
+import { storage } from '../config/firebase';
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 
 interface UpdateProfileParams {
   name?: string;
@@ -44,7 +45,8 @@ export const updateUserProfile = async (
 };
 
 /**
- * Upload profile picture
+ * Upload profile picture directly to Firebase Storage, then update user profile with the URL.
+ * Does not require a backend upload-url endpoint.
  */
 export const uploadProfilePicture = async (
   userId: string,
@@ -52,42 +54,30 @@ export const uploadProfilePicture = async (
 ): Promise<string> => {
   try {
     const token = await getIdToken();
-    
     if (!token) {
       throw new Error('Authentication token not found');
     }
-    
-    // First, get the signed URL for upload
-    const getUploadUrlResponse = await api.get('/storage/upload-url', {
-      params: {
-        contentType: 'image/jpeg',
-        extension: 'jpg',
-        directory: 'profile-pictures',
-      },
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
-    
-    const { uploadUrl, fileUrl } = getUploadUrlResponse.data;
-    
-    // Upload the image to the signed URL
-    await FileSystem.uploadAsync(uploadUrl, imageUri, {
-      httpMethod: 'PUT',
-      headers: {
-        'Content-Type': 'image/jpeg',
-      },
-    });
-    
-    // Update the user profile with the new image URL
-    await updateUserProfile(userId, { profilePictureUrl: fileUrl });
-    
-    return fileUrl;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
+    // Read the image as a blob
+    const response = await fetch(imageUri);
+    const blob = await response.blob();
+
+    // Upload to Firebase Storage: profile-pictures/<userId>.jpg
+    const storageRef = ref(storage, `profile-pictures/${userId}.jpg`);
+    await uploadBytes(storageRef, blob, { contentType: 'image/jpeg' });
+
+    // Get the public download URL
+    const downloadUrl = await getDownloadURL(storageRef);
+
+    // Persist the URL to the backend user profile
+    await updateUserProfile(userId, { profilePictureUrl: downloadUrl });
+
+    return downloadUrl;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
-    console.error('Upload profile picture error:', error.response?.data || error.message);
+    console.error('Upload profile picture error:', error.message);
     throw new Error(
-      error.response?.data?.message || 'Failed to upload profile picture'
+      error.message || 'Failed to upload profile picture'
     );
   }
 };


### PR DESCRIPTION
## Summary
BFF-S2-01 (Profile screen) and BFF-S2-02 (Settings screen) were **already substantially complete** from prior work. Both screens have:
- View/edit user profile (name, phone, email, role, ticket type)
- Avatar display with initials fallback
- Notification preference toggles (schedule + global) — wired to AppSettingsContext
- Theme toggle (dark/light mode) — wired to ThemeContext with persistence
- Performance mode toggle
- Logout and delete account flows

The only broken piece was **avatar upload** — it called `GET /storage/upload-url` which does not exist on the backend.

## What this PR fixes

### `mobile/src/config/firebase.ts`
- Added Firebase Storage initialization (`getStorage`, exported as `storage`)

### `mobile/src/services/userService.ts`
- Rewrote `uploadProfilePicture()` to upload directly to Firebase Storage
- Path: `profile-pictures/<userId>.jpg`
- Uses `fetch()` to read image as blob, `uploadBytes()` to upload, `getDownloadURL()` for public URL
- After upload: calls `PUT /users/profile` to persist the URL
- Removed dead `expo-file-system` import

## What's complete (no changes needed)
- Profile view/edit form ✅
- Avatar display + change photo button (edit mode only) ✅
- Notification preferences (schedule + global toggles) ✅
- Theme toggle (dark/light) ✅
- Performance mode toggle ✅
- All settings persisted via AppSettingsContext + AsyncStorage ✅

## TypeScript
Clean — `tsc --noEmit` passes.