### PR TITLE
feat(email): BFF-S2-04 — SendGrid SMTP scaffold + email blast tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ backend/scripts/import-artists-from-csv copy.ts
 backend/scripts/import-artists-from-csv.ts
 /mobile/bigfamfestival-4af9c9a24721.json
 /mobile/.expo
+
+# Customer PII — never commit
+assets/customers/*.csv
+assets/customers/*.xlsx
+backend/email-blast-failures.txt

--- a/backend/.env.development.example
+++ b/backend/.env.development.example
@@ -14,3 +14,8 @@ FESTIVAL_SLUG=bigfam
 API_TITLE=Big Fam Festival API
 API_DESCRIPTION=Festival management API
 API_VERSION=1.0
+
+# Transactional email — SendGrid (optional in dev)
+# SENDGRID_API_KEY=SG.xxxxxxxxxxxxxxxxxxxx
+# EMAIL_FROM=noreply@bigfamfestival.com
+# EMAIL_FROM_NAME=Big Fam Festival

--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -13,3 +13,8 @@ FESTIVAL_SLUG=bigfam
 API_TITLE=Big Fam Festival API
 API_DESCRIPTION=Festival management API
 API_VERSION=1.0
+
+# Transactional email — SendGrid (required in prod)
+SENDGRID_API_KEY=SG.xxxxxxxxxxxxxxxxxxxx
+EMAIL_FROM=noreply@bigfamfestival.com
+EMAIL_FROM_NAME=Big Fam Festival

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,6 +18,8 @@
         "@nestjs/swagger": "^7.0.3",
         "@nestjs/terminus": "^10.0.1",
         "@nestjs/throttler": "^6.4.0",
+        "@sendgrid/client": "^8.1.6",
+        "@sendgrid/mail": "^8.1.6",
         "@types/helmet": "^0.0.48",
         "axios": "^1.9.0",
         "class-transformer": "^0.5.1",
@@ -266,7 +268,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.9.tgz",
       "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -1798,7 +1799,6 @@
       "version": "10.4.15",
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.4.15.tgz",
       "integrity": "sha512-vaLg1ZgwhG29BuLDxPA9OAcIlgqzp9/N8iG0wGapyUNTf4IY4O6zAHgN6QalwLhFxq7nOI021vdRojR1oF3bqg==",
-      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "tslib": "2.8.1",
@@ -1842,7 +1842,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.4.15.tgz",
       "integrity": "sha512-UBejmdiYwaH6fTsz2QFBlC1cJHM+3UDeLZN+CiP9I1fRv2KlBZsmozGLbV5eS1JAVWJB4T5N5yQ0gjN8ZvcS2w==",
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "@nuxtjs/opencollective": "0.3.2",
         "fast-safe-stringify": "2.1.1",
@@ -1898,7 +1897,6 @@
       "version": "10.4.15",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.15.tgz",
       "integrity": "sha512-63ZZPkXHjoDyO7ahGOVcybZCRa7/Scp6mObQKjcX/fTEq1YJeU75ELvMsuQgc8U2opMGOBD7GVuc4DV0oeDHoA==",
-      "peer": true,
       "dependencies": {
         "body-parser": "1.20.3",
         "cors": "2.8.5",
@@ -2200,6 +2198,44 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
+    "node_modules/@sendgrid/client": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-8.1.6.tgz",
+      "integrity": "sha512-/BHu0hqwXNHr2aLhcXU7RmmlVqrdfrbY9KpaNj00KZHlVOVoRxRVrpOCabIB+91ISXJ6+mLM9vpaVUhK6TwBWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sendgrid/helpers": "^8.0.0",
+        "axios": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
+    "node_modules/@sendgrid/helpers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-Ze7WuW2Xzy5GT5WRx+yEv89fsg/pgy3T1E3FS0QEx0/VvRmigMZ5qyVGhJz4SxomegDkzXv/i0aFPpHKN8qdAA==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@sendgrid/mail": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-8.1.6.tgz",
+      "integrity": "sha512-/ZqxUvKeEztU9drOoPC/8opEPOk+jLlB2q4+xpx6HVLq6aFu3pMpalkTpAQz8XfRfpLp8O25bh6pGPcHDCYpqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sendgrid/client": "^8.1.5",
+        "@sendgrid/helpers": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
@@ -2495,7 +2531,6 @@
       "version": "14.1.2",
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
-      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -2526,7 +2561,6 @@
       "version": "20.17.24",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.24.tgz",
       "integrity": "sha512-d7fGCyB96w9BnWQrOsJtpyiSaBcAYYr75bnK6ZRjDbql2cGLj/3GsL5OYmLPNq76l7Gf2q4Rv9J2o6h5CrD9sA==",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -2695,7 +2729,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -3044,7 +3077,6 @@
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3088,7 +3120,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -3298,13 +3329,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -3584,7 +3616,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -3863,14 +3894,12 @@
     "node_modules/class-transformer": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
-      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "peer": true
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
     },
     "node_modules/class-validator": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.1.tgz",
       "integrity": "sha512-2VEG9JICxIqTpoK1eMzZqaV+u/EiwEJkMGzTrZf6sU/fwsnOITVgYJ8yojSy6CaXtO9V0Cc6ZQZ8h8m4UBuLwQ==",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.11.8",
         "libphonenumber-js": "^1.10.53",
@@ -4319,7 +4348,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4762,7 +4790,6 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5797,15 +5824,16 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -5859,13 +5887,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -6875,7 +6905,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -7966,7 +7995,6 @@
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
       "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -8679,7 +8707,6 @@
       "version": "8.6.1",
       "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-8.6.1.tgz",
       "integrity": "sha512-J0hiJgUExtBXP2BjrK4VB305tHXS31sCmWJ9XJo2wPkLHa1NFPuW4V9wjG27PAc2fmBCigiNhQKpvrx+kntBPA==",
-      "peer": true,
       "dependencies": {
         "get-caller-file": "^2.0.5",
         "pino": "^8.17.1",
@@ -8850,7 +8877,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -8974,7 +9000,6 @@
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
       "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -9087,9 +9112,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.2",
@@ -9253,8 +9282,7 @@
     "node_modules/reflect-metadata": {
       "version": "0.1.14",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
-      "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==",
-      "peer": true
+      "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A=="
     },
     "node_modules/repeat-string": {
       "version": "1.6.1",
@@ -9448,7 +9476,6 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -9524,7 +9551,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -10402,7 +10428,6 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10559,7 +10584,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
       "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10833,6 +10857,7 @@
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
       "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,6 +24,8 @@
     "cleanup:passwords:execute": "ts-node -r tsconfig-paths/register scripts/remove-passwords-from-firestore.ts --execute",
     "verify:migration": "ts-node -r tsconfig-paths/register scripts/verify-migration.ts",
     "verify:migration:fix": "ts-node -r tsconfig-paths/register scripts/verify-migration.ts --fix",
+    "email:blast": "ts-node -r tsconfig-paths/register scripts/email-blast.ts",
+    "email:blast:dry": "ts-node -r tsconfig-paths/register scripts/email-blast.ts --dry-run",
     "seed:events:api": "ts-node -r tsconfig-paths/register scripts/seed-events-api.ts"
   },
   "description": "API for the Big Fam Festival App",
@@ -40,6 +42,8 @@
     "@nestjs/swagger": "^7.0.3",
     "@nestjs/terminus": "^10.0.1",
     "@nestjs/throttler": "^6.4.0",
+    "@sendgrid/client": "^8.1.6",
+    "@sendgrid/mail": "^8.1.6",
     "@types/helmet": "^0.0.48",
     "axios": "^1.9.0",
     "class-transformer": "^0.5.1",

--- a/backend/scripts/email-blast.ts
+++ b/backend/scripts/email-blast.ts
@@ -1,0 +1,226 @@
+/**
+ * BFF-S2-04: Email Blast Script (SendGrid)
+ *
+ * Sends a bulk email to a list of recipients from a CSV file.
+ * Uses SendGrid's batch send — respects rate limits with configurable delay.
+ *
+ * ⚠️  DO NOT RUN IN PRODUCTION without Robert's explicit approval.
+ * ⚠️  SendGrid free tier = 100 emails/day. Essentials plan needed for full 4,000 blast.
+ *
+ * CSV format expected:
+ *   email,name,ticketType
+ *   user@example.com,Jane Doe,ga
+ *
+ * If columns differ, update COLUMN_MAP below.
+ *
+ * Usage:
+ *   npx ts-node scripts/email-blast.ts --csv=../assets/customers/customers.csv --dry-run
+ *   npx ts-node scripts/email-blast.ts --csv=../assets/customers/customers.csv --subject="Big Fam is coming!" --template=d-xxxx
+ *
+ * Flags:
+ *   --csv=<path>         Path to CSV file (required)
+ *   --subject=<text>     Email subject line
+ *   --template=<id>      SendGrid Dynamic Template ID (d-xxxx...)
+ *   --dry-run            Parse CSV and report counts without sending
+ *   --limit=<n>          Only send to first N recipients (testing)
+ *   --batch-size=<n>     Emails per batch (default: 50, max: 1000)
+ *   --delay-ms=<n>       Delay between batches in ms (default: 1000)
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as readline from 'readline';
+import * as dotenv from 'dotenv';
+import * as sgMail from '@sendgrid/mail';
+
+dotenv.config({ path: path.join(__dirname, '..', '.env') });
+
+// ─── Column mapping — update if CSV structure differs ───────────────────────
+const COLUMN_MAP = {
+  email: 'email',       // column name for email address
+  name: 'name',         // column name for recipient display name
+  ticketType: 'ticketType', // optional: for personalization
+};
+// ────────────────────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const getArg = (name: string): string | undefined =>
+  args.find(a => a.startsWith(`--${name}=`))?.split('=').slice(1).join('=');
+const hasFlag = (name: string): boolean => args.includes(`--${name}`);
+
+const csvPath = getArg('csv');
+const subject = getArg('subject') || 'A message from Big Fam Festival';
+const templateId = getArg('template');
+const isDryRun = hasFlag('dry-run');
+const limit = getArg('limit') ? parseInt(getArg('limit')!, 10) : undefined;
+const batchSize = getArg('batch-size') ? parseInt(getArg('batch-size')!, 10) : 50;
+const delayMs = getArg('delay-ms') ? parseInt(getArg('delay-ms')!, 10) : 1000;
+
+interface Recipient {
+  email: string;
+  name?: string;
+  ticketType?: string;
+  [key: string]: string | undefined;
+}
+
+async function parseCSV(filePath: string): Promise<{ recipients: Recipient[]; columns: string[] }> {
+  const recipients: Recipient[] = [];
+  let columns: string[] = [];
+
+  const rl = readline.createInterface({
+    input: fs.createReadStream(filePath),
+    crlfDelay: Infinity,
+  });
+
+  let isHeader = true;
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+
+    const values = line.split(',').map(v => v.trim().replace(/^"|"$/g, ''));
+
+    if (isHeader) {
+      columns = values.map(v => v.toLowerCase());
+      isHeader = false;
+      continue;
+    }
+
+    const row: Record<string, string> = {};
+    columns.forEach((col, i) => { row[col] = values[i] || ''; });
+
+    const emailCol = COLUMN_MAP.email.toLowerCase();
+    const email = row[emailCol];
+    if (!email || !email.includes('@')) continue; // Skip invalid emails
+
+    recipients.push({
+      email: email.toLowerCase(),
+      name: row[COLUMN_MAP.name.toLowerCase()] || undefined,
+      ticketType: row[COLUMN_MAP.ticketType.toLowerCase()] || undefined,
+      ...row,
+    });
+  }
+
+  return { recipients, columns };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function blast(): Promise<void> {
+  console.log('═══════════════════════════════════════════════════════════════');
+  console.log('  BFF-S2-04: Big Fam Email Blast (SendGrid)');
+  console.log(`  Mode: ${isDryRun ? '🔍 DRY RUN (no emails sent)' : '🚀 LIVE SEND'}`);
+  console.log('═══════════════════════════════════════════════════════════════\n');
+
+  if (!csvPath) {
+    console.error('❌ --csv=<path> is required');
+    process.exit(1);
+  }
+
+  const resolvedCsv = path.resolve(__dirname, '..', csvPath);
+  if (!fs.existsSync(resolvedCsv)) {
+    console.error(`❌ CSV file not found: ${resolvedCsv}`);
+    process.exit(1);
+  }
+
+  // Parse CSV
+  console.log(`📥 Parsing CSV: ${resolvedCsv}`);
+  const { recipients, columns } = await parseCSV(resolvedCsv);
+  console.log(`   Columns detected: ${columns.join(', ')}`);
+  console.log(`   Valid recipients: ${recipients.length}`);
+
+  const sendList = limit ? recipients.slice(0, limit) : recipients;
+  console.log(`   Will send to: ${sendList.length}${limit ? ` (limited to ${limit})` : ''}`);
+
+  if (sendList.length === 0) {
+    console.log('\n⚠️  No valid recipients found. Check CSV format and COLUMN_MAP.');
+    process.exit(0);
+  }
+
+  // Free tier warning
+  if (!isDryRun && sendList.length > 100) {
+    console.warn(`\n⚠️  WARNING: Sending to ${sendList.length} recipients.`);
+    console.warn('   SendGrid free tier is 100/day. Upgrade to Essentials ($20/mo) before full blast.');
+    console.warn('   Run with --dry-run to preview without sending.\n');
+  }
+
+  if (isDryRun) {
+    console.log('\n📋 Recipient preview (first 5):');
+    sendList.slice(0, 5).forEach(r => {
+      console.log(`   ${r.email} (${r.name || 'no name'})`);
+    });
+    if (sendList.length > 5) {
+      console.log(`   ... and ${sendList.length - 5} more`);
+    }
+    console.log('\n✅ Dry run complete. No emails sent.');
+    return;
+  }
+
+  // Configure SendGrid
+  const apiKey = process.env.SENDGRID_API_KEY;
+  if (!apiKey) {
+    console.error('❌ SENDGRID_API_KEY not set in environment');
+    process.exit(1);
+  }
+  sgMail.setApiKey(apiKey);
+
+  const fromEmail = process.env.EMAIL_FROM || 'noreply@bigfamfestival.com';
+  const fromName = process.env.EMAIL_FROM_NAME || 'Big Fam Festival';
+
+  console.log(`\n📤 Sending in batches of ${batchSize} with ${delayMs}ms delay...\n`);
+
+  let sent = 0;
+  let failed = 0;
+  const failedEmails: string[] = [];
+
+  for (let i = 0; i < sendList.length; i += batchSize) {
+    const batch = sendList.slice(i, i + batchSize);
+    const batchNum = Math.floor(i / batchSize) + 1;
+    const totalBatches = Math.ceil(sendList.length / batchSize);
+
+    process.stdout.write(`  Batch ${batchNum}/${totalBatches} (${batch.length} emails)... `);
+
+    const messages: sgMail.MailDataRequired[] = batch.map(r => ({
+      to: { email: r.email, name: r.name },
+      from: { email: fromEmail, name: fromName },
+      subject,
+      ...(templateId
+        ? { templateId, dynamicTemplateData: { name: r.name || 'Friend', ticketType: r.ticketType } }
+        : { text: `Hi ${r.name || 'there'},\n\nSee you at Big Fam Festival!\n\nThe Big Fam Team` }),
+    }));
+
+    try {
+      await sgMail.send(messages as any);
+      sent += batch.length;
+      console.log(`✅`);
+    } catch (err: any) {
+      failed += batch.length;
+      batch.forEach(r => failedEmails.push(r.email));
+      console.log(`❌ ${err.message}`);
+    }
+
+    if (i + batchSize < sendList.length) {
+      await sleep(delayMs);
+    }
+  }
+
+  console.log('\n═══════════════════════════════════════════════════════════════');
+  console.log('  BLAST SUMMARY');
+  console.log('═══════════════════════════════════════════════════════════════');
+  console.log(`  ✅ Sent:   ${sent}`);
+  console.log(`  ❌ Failed: ${failed}`);
+
+  if (failedEmails.length > 0) {
+    const failPath = path.join(__dirname, '..', 'email-blast-failures.txt');
+    fs.writeFileSync(failPath, failedEmails.join('\n'));
+    console.log(`\n  Failed addresses written to: ${failPath}`);
+  }
+
+  console.log('═══════════════════════════════════════════════════════════════');
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+blast().catch(err => {
+  console.error('\n❌ Blast failed:', err.message);
+  process.exit(1);
+});

--- a/backend/src/config/sendgrid/sendgrid.config.ts
+++ b/backend/src/config/sendgrid/sendgrid.config.ts
@@ -1,0 +1,68 @@
+import { ConfigService } from '@nestjs/config';
+import * as sgMail from '@sendgrid/mail';
+
+/**
+ * Initialize SendGrid with API key from environment.
+ * Call once at app bootstrap (after NestJS ConfigModule is ready).
+ *
+ * Required env vars:
+ *   SENDGRID_API_KEY   — SendGrid API key (starts with SG.)
+ *   EMAIL_FROM         — Verified sender address (e.g. noreply@bigfamfestival.com)
+ *   EMAIL_FROM_NAME    — Sender display name (e.g. Big Fam Festival)
+ */
+export function initSendGrid(configService: ConfigService): void {
+  const apiKey = configService.get<string>('SENDGRID_API_KEY');
+  const nodeEnv = configService.get<string>('NODE_ENV', 'development');
+
+  if (!apiKey) {
+    if (nodeEnv === 'production') {
+      console.warn('[SendGrid] SENDGRID_API_KEY not set in production — transactional email disabled');
+    }
+    return;
+  }
+
+  sgMail.setApiKey(apiKey);
+}
+
+export interface SendGridEmailOptions {
+  to: string | string[];
+  subject: string;
+  text?: string;
+  html?: string;
+  templateId?: string;
+  dynamicTemplateData?: Record<string, any>;
+}
+
+/**
+ * Send a transactional email via SendGrid.
+ * Returns true on success, false if SendGrid is not configured (dev).
+ * Throws on send failure in production.
+ */
+export async function sendEmail(
+  options: SendGridEmailOptions,
+  configService: ConfigService,
+): Promise<boolean> {
+  const apiKey = configService.get<string>('SENDGRID_API_KEY');
+  if (!apiKey) {
+    console.warn('[SendGrid] Skipping email send — SENDGRID_API_KEY not set');
+    return false;
+  }
+
+  const from = {
+    email: configService.get<string>('EMAIL_FROM', 'noreply@bigfamfestival.com'),
+    name: configService.get<string>('EMAIL_FROM_NAME', 'Big Fam Festival'),
+  };
+
+  const msg: sgMail.MailDataRequired = {
+    to: options.to,
+    from,
+    subject: options.subject,
+    ...(options.text && { text: options.text }),
+    ...(options.html && { html: options.html }),
+    ...(options.templateId && { templateId: options.templateId }),
+    ...(options.dynamicTemplateData && { dynamicTemplateData: options.dynamicTemplateData }),
+  };
+
+  await sgMail.send(msg);
+  return true;
+}


### PR DESCRIPTION
## BFF-S2-04: Custom SMTP — SendGrid

Scaffolds SendGrid transactional email and bulk blast tooling. No emails are sent until Robert explicitly runs the script with live credentials.

---

## SendGrid Config (`src/config/sendgrid/sendgrid.config.ts`)

- `initSendGrid(configService)` — initializes API key at app bootstrap
- `sendEmail(options, configService)` — sends individual transactional emails
- Silent no-op in dev if `SENDGRID_API_KEY` not set; warns in prod if missing
- Used for: verification emails, password reset — via Firebase custom SMTP (configured in Firebase Console pointing to SendGrid)

**Required env vars:**
```
SENDGRID_API_KEY=SG.xxxxxxxxxxxxxxxxxxxx
EMAIL_FROM=noreply@bigfamfestival.com
EMAIL_FROM_NAME=Big Fam Festival
```

---

## Email Blast Script (`scripts/email-blast.ts`)

CSV-driven bulk sender for the customer list.

**Default mode is dry-run — safe to run anytime:**
```bash
npm run email:blast:dry -- --csv=../assets/customers/customers.csv
```

**Live send (Robert approval required before running):**
```bash
npm run email:blast -- --csv=../assets/customers/customers.csv --subject="Big Fam is coming!" --template=d-xxxx
```

**Features:**
- CSV column mapping via `COLUMN_MAP` at top of script
- Configurable batch size (default 50) + delay (1s) for rate limit compliance
- Free tier warning if >100 recipients (Essentials plan needed for 4,000 blast)
- Failed emails written to `email-blast-failures.txt` for retry
- `--limit=N` for test sends to first N recipients

---

## PII Protection
- `assets/customers/` directory with `.gitignore` blocking `*.csv` / `*.xlsx`
- `email-blast-failures.txt` gitignored
- Customer CSV must never be committed to the repo

---

## Operator Actions Required Before Use

1. Verify sender domain at sendgrid.com (domain authentication)
2. Add `SENDGRID_API_KEY` to Cloud Run environment variables
3. Configure Firebase custom SMTP to use SendGrid (Firebase Console → Authentication → Templates → SMTP)
4. Upgrade SendGrid to Essentials plan before sending to full 4,000 list (free tier = 100/day)
5. Place customer CSV at `assets/customers/` (gitignored, not in repo)