### PR TITLE
feat(admin): BFF-S3-06 — Admin Control Panel backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ backend/scripts/import-artists-from-csv.ts
 assets/customers/*.csv
 assets/customers/*.xlsx
 backend/email-blast-failures.txt
+backend/bigfam-serviceaccount.json
+BFF-S1-01-notification-backend-audit.md

--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -1,0 +1,203 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Put,
+  Delete,
+  Param,
+  Query,
+  Body,
+  Request,
+  ParseIntPipe,
+  DefaultValuePipe,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiQuery,
+  ApiParam,
+} from '@nestjs/swagger';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { Role } from '../auth/enums/role.enum';
+import { AdminService } from './admin.service';
+import { AdminUpdateUserDto } from '../users/dto/admin-update-user.dto';
+import { CreateEventDto } from '../auth/dto/create-event.dto';
+import { UpdateEventDto } from '../auth/dto/update-event.dto';
+import { CreateShiftDto } from '../shifts/dto/create-shift.dto';
+import { UpdateShiftDto } from '../shifts/dto/update-shift.dto';
+
+@ApiTags('admin')
+@ApiBearerAuth()
+@Roles(Role.ADMIN)
+@Controller('admin')
+export class AdminController {
+  constructor(private readonly adminService: AdminService) {}
+
+  // ── Stats ──────────────────────────────────────────────────────────
+
+  @Get('stats')
+  @ApiOperation({ summary: 'Get admin dashboard stats' })
+  @ApiResponse({ status: 200, description: 'Dashboard statistics' })
+  async getStats() {
+    return this.adminService.getStats();
+  }
+
+  // ── User Management ────────────────────────────────────────────────
+
+  @Get('users')
+  @ApiOperation({ summary: 'List users with search, role filter, and pagination' })
+  @ApiQuery({ name: 'search', required: false, description: 'Search by name or email' })
+  @ApiQuery({ name: 'role', required: false, description: 'Filter by role' })
+  @ApiQuery({ name: 'page', required: false, description: 'Page number (default: 1)' })
+  @ApiQuery({ name: 'limit', required: false, description: 'Items per page (default: 20)' })
+  @ApiResponse({ status: 200, description: 'Paginated user list' })
+  async listUsers(
+    @Query('search') search?: string,
+    @Query('role') role?: string,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page?: number,
+    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit?: number,
+  ) {
+    return this.adminService.listUsers(search, role, page, limit);
+  }
+
+  @Get('users/:id')
+  @ApiOperation({ summary: 'Get user detail by ID' })
+  @ApiParam({ name: 'id', description: 'User ID' })
+  @ApiResponse({ status: 200, description: 'User details' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  async getUser(@Param('id') id: string) {
+    return this.adminService.getUser(id);
+  }
+
+  @Patch('users/:id')
+  @ApiOperation({ summary: 'Update user (including role)' })
+  @ApiParam({ name: 'id', description: 'User ID' })
+  @ApiResponse({ status: 200, description: 'Updated user' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  async updateUser(
+    @Param('id') id: string,
+    @Body() dto: AdminUpdateUserDto,
+  ) {
+    return this.adminService.updateUser(id, dto);
+  }
+
+  // ── Event Management ───────────────────────────────────────────────
+
+  @Post('events')
+  @ApiOperation({ summary: 'Create event (admin)' })
+  @ApiResponse({ status: 201, description: 'Event created' })
+  async createEvent(@Body() dto: CreateEventDto, @Request() req) {
+    dto.createdBy = req.user.id;
+    return this.adminService.createEvent(dto);
+  }
+
+  @Patch('events/:id')
+  @ApiOperation({ summary: 'Update event (admin)' })
+  @ApiParam({ name: 'id', description: 'Event ID' })
+  @ApiResponse({ status: 200, description: 'Event updated' })
+  @ApiResponse({ status: 404, description: 'Event not found' })
+  async updateEvent(
+    @Param('id') id: string,
+    @Body() dto: UpdateEventDto,
+  ) {
+    return this.adminService.updateEvent(id, dto);
+  }
+
+  @Delete('events/:id')
+  @ApiOperation({ summary: 'Delete event (admin)' })
+  @ApiParam({ name: 'id', description: 'Event ID' })
+  @ApiResponse({ status: 200, description: 'Event deleted' })
+  @ApiResponse({ status: 404, description: 'Event not found' })
+  async deleteEvent(@Param('id') id: string) {
+    return this.adminService.deleteEvent(id);
+  }
+
+  // ── Shift Management ──────────────────────────────────────────────
+
+  @Get('shifts')
+  @ApiOperation({ summary: 'List shifts with optional date/role filter' })
+  @ApiQuery({ name: 'date', required: false, description: 'Filter by date (YYYY-MM-DD)' })
+  @ApiQuery({ name: 'role', required: false, description: 'Filter by role' })
+  @ApiResponse({ status: 200, description: 'List of shifts' })
+  async listShifts(
+    @Query('date') date?: string,
+    @Query('role') role?: string,
+  ) {
+    return this.adminService.listShifts({ date, role });
+  }
+
+  @Post('shifts')
+  @ApiOperation({ summary: 'Create a shift' })
+  @ApiResponse({ status: 201, description: 'Shift created' })
+  async createShift(@Body() dto: CreateShiftDto) {
+    return this.adminService.createShift(dto);
+  }
+
+  @Patch('shifts/:id')
+  @ApiOperation({ summary: 'Update a shift' })
+  @ApiParam({ name: 'id', description: 'Shift ID' })
+  @ApiResponse({ status: 200, description: 'Shift updated' })
+  @ApiResponse({ status: 404, description: 'Shift not found' })
+  async updateShift(
+    @Param('id') id: string,
+    @Body() dto: UpdateShiftDto,
+  ) {
+    return this.adminService.updateShift(id, dto);
+  }
+
+  @Delete('shifts/:id')
+  @ApiOperation({ summary: 'Delete a shift' })
+  @ApiParam({ name: 'id', description: 'Shift ID' })
+  @ApiResponse({ status: 200, description: 'Shift deleted' })
+  @ApiResponse({ status: 404, description: 'Shift not found' })
+  async deleteShift(@Param('id') id: string) {
+    return this.adminService.deleteShift(id);
+  }
+
+  // ── Schedule Management ────────────────────────────────────────────
+
+  @Get('schedule/:userId')
+  @ApiOperation({ summary: "Get any user's schedule (admin bypass)" })
+  @ApiParam({ name: 'userId', description: 'User ID' })
+  @ApiResponse({ status: 200, description: "User's schedule" })
+  async getUserSchedule(@Param('userId') userId: string) {
+    return this.adminService.getUserSchedule(userId);
+  }
+
+  @Put('schedule/:userId')
+  @ApiOperation({ summary: "Set/replace a user's schedule" })
+  @ApiParam({ name: 'userId', description: 'User ID' })
+  @ApiResponse({ status: 200, description: 'Schedule replaced' })
+  async setUserSchedule(
+    @Param('userId') userId: string,
+    @Body() body: { eventIds: string[] },
+  ) {
+    return this.adminService.setUserSchedule(userId, body.eventIds);
+  }
+
+  @Post('schedule/:userId')
+  @ApiOperation({ summary: "Add event to user's schedule" })
+  @ApiParam({ name: 'userId', description: 'User ID' })
+  @ApiResponse({ status: 201, description: 'Event added to schedule' })
+  async addToUserSchedule(
+    @Param('userId') userId: string,
+    @Body() body: { eventId: string },
+  ) {
+    return this.adminService.addToUserSchedule(userId, body.eventId);
+  }
+
+  @Delete('schedule/:userId/:eventId')
+  @ApiOperation({ summary: "Remove event from user's schedule" })
+  @ApiParam({ name: 'userId', description: 'User ID' })
+  @ApiParam({ name: 'eventId', description: 'Event ID' })
+  @ApiResponse({ status: 200, description: 'Event removed from schedule' })
+  async removeFromUserSchedule(
+    @Param('userId') userId: string,
+    @Param('eventId') eventId: string,
+  ) {
+    return this.adminService.removeFromUserSchedule(userId, eventId);
+  }
+}

--- a/backend/src/admin/admin.module.ts
+++ b/backend/src/admin/admin.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { AdminController } from './admin.controller';
+import { AdminService } from './admin.service';
+import { FirestoreModule } from '../config/firestore/firestore.module';
+import { UsersModule } from '../users/users.module';
+import { EventsModule } from '../events/events.module';
+import { NotificationsModule } from '../notifications/notifications.module';
+import { ShiftsModule } from '../shifts/shifts.module';
+import { ScheduleModule } from '../schedule/schedule.module';
+
+@Module({
+  imports: [
+    FirestoreModule,
+    UsersModule,
+    EventsModule,
+    NotificationsModule,
+    ShiftsModule,
+    ScheduleModule,
+  ],
+  controllers: [AdminController],
+  providers: [AdminService],
+})
+export class AdminModule {}

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -1,0 +1,179 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { FirestoreService } from '../config/firestore/firestore.service';
+import { UsersService } from '../users/users.service';
+import { EventsService } from '../events/events.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { ShiftsService } from '../shifts/shifts.service';
+import { ScheduleService } from '../schedule/schedule.service';
+import { AdminUpdateUserDto } from '../users/dto/admin-update-user.dto';
+import { CreateEventDto } from '../auth/dto/create-event.dto';
+import { UpdateEventDto } from '../auth/dto/update-event.dto';
+import { CreateShiftDto } from '../shifts/dto/create-shift.dto';
+import { UpdateShiftDto } from '../shifts/dto/update-shift.dto';
+import { Event } from '../events/event.interface';
+
+@Injectable()
+export class AdminService {
+  private readonly logger = new Logger(AdminService.name);
+
+  constructor(
+    private readonly firestoreService: FirestoreService,
+    private readonly usersService: UsersService,
+    private readonly eventsService: EventsService,
+    private readonly notificationsService: NotificationsService,
+    private readonly shiftsService: ShiftsService,
+    private readonly scheduleService: ScheduleService,
+  ) {}
+
+  // ── Stats ──────────────────────────────────────────────────────────
+
+  async getStats(): Promise<{
+    totalUsers: number;
+    totalEvents: number;
+    totalNotifications: number;
+    usersByRole: Record<string, number>;
+  }> {
+    const [users, events, notifications] = await Promise.all([
+      this.firestoreService.getAll<{ role?: string }>('users'),
+      this.firestoreService.getAll('events'),
+      this.firestoreService.getAll('notifications'),
+    ]);
+
+    const usersByRole: Record<string, number> = {};
+    for (const user of users) {
+      const role = user.role || 'attendee';
+      usersByRole[role] = (usersByRole[role] || 0) + 1;
+    }
+
+    return {
+      totalUsers: users.length,
+      totalEvents: events.length,
+      totalNotifications: notifications.length,
+      usersByRole,
+    };
+  }
+
+  // ── User Management ────────────────────────────────────────────────
+
+  async listUsers(
+    search?: string,
+    role?: string,
+    page = 1,
+    limit = 20,
+  ): Promise<{
+    users: any[];
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  }> {
+    let users = await this.firestoreService.getAll<any>('users');
+
+    // Filter by role
+    if (role) {
+      users = users.filter((u) => u.role === role);
+    }
+
+    // Filter by search (name or email, case-insensitive)
+    if (search) {
+      const q = search.toLowerCase();
+      users = users.filter(
+        (u) =>
+          (u.name && u.name.toLowerCase().includes(q)) ||
+          (u.email && u.email.toLowerCase().includes(q)),
+      );
+    }
+
+    // Sort by name
+    users.sort((a, b) =>
+      (a.name || '').localeCompare(b.name || ''),
+    );
+
+    const total = users.length;
+    const totalPages = Math.ceil(total / limit);
+    const start = (page - 1) * limit;
+    const paginatedUsers = users.slice(start, start + limit);
+
+    return { users: paginatedUsers, total, page, limit, totalPages };
+  }
+
+  async getUser(id: string) {
+    return this.usersService.findById(id);
+  }
+
+  async updateUser(id: string, dto: AdminUpdateUserDto) {
+    return this.usersService.update(id, dto);
+  }
+
+  // ── Event Management ───────────────────────────────────────────────
+
+  async createEvent(dto: CreateEventDto) {
+    return this.eventsService.create(dto);
+  }
+
+  async updateEvent(id: string, dto: UpdateEventDto) {
+    return this.eventsService.update(id, dto);
+  }
+
+  async deleteEvent(id: string) {
+    return this.eventsService.remove(id);
+  }
+
+  // ── Shift Management ──────────────────────────────────────────────
+
+  async listShifts(filters?: { date?: string; role?: string }) {
+    return this.shiftsService.findAll(filters);
+  }
+
+  async createShift(dto: CreateShiftDto) {
+    return this.shiftsService.create(dto);
+  }
+
+  async updateShift(id: string, dto: UpdateShiftDto) {
+    return this.shiftsService.update(id, dto);
+  }
+
+  async deleteShift(id: string) {
+    return this.shiftsService.remove(id);
+  }
+
+  // ── Schedule Management ────────────────────────────────────────────
+
+  async getUserSchedule(userId: string): Promise<Event[]> {
+    return this.scheduleService.getSchedule(userId);
+  }
+
+  async setUserSchedule(
+    userId: string,
+    eventIds: string[],
+  ): Promise<Event[]> {
+    // Clear existing schedule
+    const existing = await this.scheduleService.getSchedule(userId);
+    for (const event of existing) {
+      await this.scheduleService.removeFromSchedule(userId, {
+        event_id: event.id,
+      });
+    }
+
+    // Add new events
+    for (const eventId of eventIds) {
+      await this.scheduleService.addToSchedule(userId, {
+        event_id: eventId,
+      });
+    }
+
+    return this.scheduleService.getSchedule(userId);
+  }
+
+  async addToUserSchedule(userId: string, eventId: string) {
+    return this.scheduleService.addToSchedule(userId, {
+      event_id: eventId,
+    });
+  }
+
+  async removeFromUserSchedule(userId: string, eventId: string) {
+    return this.scheduleService.removeFromSchedule(userId, {
+      event_id: eventId,
+    });
+  }
+}

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -67,6 +67,7 @@ export class AdminService {
     limit: number;
     totalPages: number;
   }> {
+    // TODO: move filtering to Firestore query when user count exceeds 1K
     let users = await this.firestoreService.getAll<any>('users');
 
     // Filter by role
@@ -149,18 +150,18 @@ export class AdminService {
   ): Promise<Event[]> {
     // Clear existing schedule
     const existing = await this.scheduleService.getSchedule(userId);
-    for (const event of existing) {
-      await this.scheduleService.removeFromSchedule(userId, {
-        event_id: event.id,
-      });
-    }
+    await Promise.all(
+      existing.map((e) =>
+        this.scheduleService.removeFromSchedule(userId, { event_id: e.id }),
+      ),
+    );
 
     // Add new events
-    for (const eventId of eventIds) {
-      await this.scheduleService.addToSchedule(userId, {
-        event_id: eventId,
-      });
-    }
+    await Promise.all(
+      eventIds.map((id) =>
+        this.scheduleService.addToSchedule(userId, { event_id: id }),
+      ),
+    );
 
     return this.scheduleService.getSchedule(userId);
   }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -20,6 +20,8 @@ import { APP_GUARD } from '@nestjs/core';
 import { FirebaseAuthGuard } from './auth/guards/firebase-auth.guard';
 import { RolesGuard } from './auth/guards/roles.guard';
 import { ArtistsModule } from './artists/artists.module';
+import { ShiftsModule } from './shifts/shifts.module';
+import { AdminModule } from './admin/admin.module';
 import { TenantMiddleware } from './common/middleware/tenant.middleware';
 
 @Module({
@@ -90,6 +92,8 @@ import { TenantMiddleware } from './common/middleware/tenant.middleware';
     CampsitesModule,
     ArtistsModule,
     NotificationsModule,
+    ShiftsModule,
+    AdminModule,
 
     // Debug modules (non-production only)
     ...(process.env.NODE_ENV !== 'production' ? [DebugModule] : []),

--- a/backend/src/shifts/dto/create-shift.dto.ts
+++ b/backend/src/shifts/dto/create-shift.dto.ts
@@ -1,0 +1,57 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Matches,
+} from 'class-validator';
+
+export class CreateShiftDto {
+  @ApiProperty({ example: 'user123', description: 'ID of the assigned user' })
+  @IsString()
+  @IsNotEmpty()
+  userId: string;
+
+  @ApiProperty({ example: 'Jane Doe', description: 'Name of the assigned user' })
+  @IsString()
+  @IsNotEmpty()
+  userName: string;
+
+  @ApiProperty({ example: 'staff', description: 'Role for the shift' })
+  @IsString()
+  @IsNotEmpty()
+  role: string;
+
+  @ApiProperty({ example: '2026-06-20', description: 'Shift date (YYYY-MM-DD)' })
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, { message: 'Date must be in YYYY-MM-DD format' })
+  date: string;
+
+  @ApiProperty({ example: '08:00', description: 'Start time (HH:MM)' })
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^([01]\d|2[0-3]):([0-5]\d)$/, { message: 'Start time must be in HH:MM format' })
+  startTime: string;
+
+  @ApiProperty({ example: '16:00', description: 'End time (HH:MM)' })
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^([01]\d|2[0-3]):([0-5]\d)$/, { message: 'End time must be in HH:MM format' })
+  endTime: string;
+
+  @ApiProperty({ example: 'Main Gate', description: 'Shift location' })
+  @IsString()
+  @IsNotEmpty()
+  location: string;
+
+  @ApiProperty({ example: 'Main Stage', description: 'Stage assignment', required: false })
+  @IsString()
+  @IsOptional()
+  stage?: string;
+
+  @ApiProperty({ example: 'Bring radio', description: 'Additional notes', required: false })
+  @IsString()
+  @IsOptional()
+  notes?: string;
+}

--- a/backend/src/shifts/dto/update-shift.dto.ts
+++ b/backend/src/shifts/dto/update-shift.dto.ts
@@ -1,0 +1,56 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsOptional,
+  IsString,
+  Matches,
+} from 'class-validator';
+
+export class UpdateShiftDto {
+  @ApiProperty({ example: 'user123', required: false })
+  @IsString()
+  @IsOptional()
+  userId?: string;
+
+  @ApiProperty({ example: 'Jane Doe', required: false })
+  @IsString()
+  @IsOptional()
+  userName?: string;
+
+  @ApiProperty({ example: 'volunteer', required: false })
+  @IsString()
+  @IsOptional()
+  role?: string;
+
+  @ApiProperty({ example: '2026-06-21', required: false })
+  @IsString()
+  @IsOptional()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, { message: 'Date must be in YYYY-MM-DD format' })
+  date?: string;
+
+  @ApiProperty({ example: '10:00', required: false })
+  @IsString()
+  @IsOptional()
+  @Matches(/^([01]\d|2[0-3]):([0-5]\d)$/, { message: 'Start time must be in HH:MM format' })
+  startTime?: string;
+
+  @ApiProperty({ example: '18:00', required: false })
+  @IsString()
+  @IsOptional()
+  @Matches(/^([01]\d|2[0-3]):([0-5]\d)$/, { message: 'End time must be in HH:MM format' })
+  endTime?: string;
+
+  @ApiProperty({ example: 'VIP Area', required: false })
+  @IsString()
+  @IsOptional()
+  location?: string;
+
+  @ApiProperty({ example: 'Side Stage', required: false })
+  @IsString()
+  @IsOptional()
+  stage?: string;
+
+  @ApiProperty({ example: 'Updated notes', required: false })
+  @IsString()
+  @IsOptional()
+  notes?: string;
+}

--- a/backend/src/shifts/interfaces/shift.interface.ts
+++ b/backend/src/shifts/interfaces/shift.interface.ts
@@ -1,0 +1,14 @@
+export interface Shift {
+  id: string;
+  userId: string;
+  userName: string;
+  role: string;
+  date: string; // YYYY-MM-DD
+  startTime: string; // HH:MM
+  endTime: string; // HH:MM
+  location: string;
+  stage?: string;
+  notes?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/backend/src/shifts/shifts.module.ts
+++ b/backend/src/shifts/shifts.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ShiftsService } from './shifts.service';
+import { FirestoreModule } from '../config/firestore/firestore.module';
+
+@Module({
+  imports: [FirestoreModule],
+  providers: [ShiftsService],
+  exports: [ShiftsService],
+})
+export class ShiftsModule {}

--- a/backend/src/shifts/shifts.service.ts
+++ b/backend/src/shifts/shifts.service.ts
@@ -1,0 +1,87 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { FirestoreService } from '../config/firestore/firestore.service';
+import { Shift } from './interfaces/shift.interface';
+import { CreateShiftDto } from './dto/create-shift.dto';
+import { UpdateShiftDto } from './dto/update-shift.dto';
+
+@Injectable()
+export class ShiftsService {
+  private readonly collectionName = 'shifts';
+  private readonly logger = new Logger(ShiftsService.name);
+
+  constructor(private readonly firestoreService: FirestoreService) {}
+
+  async create(createShiftDto: CreateShiftDto): Promise<Shift> {
+    const now = new Date();
+    const shiftData = {
+      ...createShiftDto,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    const { id, data } = await this.firestoreService.create<typeof shiftData>(
+      this.collectionName,
+      shiftData,
+    );
+
+    return { id, ...data } as Shift;
+  }
+
+  async findById(id: string): Promise<Shift> {
+    const shift = await this.firestoreService.get<Shift>(
+      this.collectionName,
+      id,
+    );
+    if (!shift) {
+      throw new NotFoundException(`Shift with ID "${id}" not found`);
+    }
+    return shift;
+  }
+
+  async findAll(filters?: {
+    date?: string;
+    role?: string;
+    userId?: string;
+  }): Promise<Shift[]> {
+    const shifts = await this.firestoreService.getAll<Shift>(
+      this.collectionName,
+    );
+
+    let filtered = shifts;
+
+    if (filters?.date) {
+      filtered = filtered.filter((s) => s.date === filters.date);
+    }
+    if (filters?.role) {
+      filtered = filtered.filter((s) => s.role === filters.role);
+    }
+    if (filters?.userId) {
+      filtered = filtered.filter((s) => s.userId === filters.userId);
+    }
+
+    return filtered.sort((a, b) => {
+      const dtA = `${a.date}T${a.startTime}`;
+      const dtB = `${b.date}T${b.startTime}`;
+      return dtA.localeCompare(dtB);
+    });
+  }
+
+  async update(id: string, updateShiftDto: UpdateShiftDto): Promise<Shift> {
+    await this.findById(id); // ensure exists
+    const updateData = {
+      ...updateShiftDto,
+      updatedAt: new Date(),
+    };
+    await this.firestoreService.update<typeof updateData>(
+      this.collectionName,
+      id,
+      updateData,
+    );
+    return this.findById(id);
+  }
+
+  async remove(id: string): Promise<void> {
+    await this.findById(id); // ensure exists
+    await this.firestoreService.delete(this.collectionName, id);
+  }
+}


### PR DESCRIPTION
## BFF-S3-06: Admin Control Panel Backend

### New modules
- **AdminModule** (`/admin/*`) — consolidated admin-only endpoints with `@Roles(Role.ADMIN)`
- **ShiftsModule** — staff/volunteer shift CRUD with Firestore persistence

### Endpoints (15 total, all admin-only)

| Method | Path | Description |
|--------|------|-------------|
| GET | `/admin/stats` | Dashboard stats (users, events, notifications, usersByRole) |
| GET | `/admin/users` | Paginated user list with search + role filter |
| GET | `/admin/users/:id` | User detail |
| PATCH | `/admin/users/:id` | Update user (incl. role assignment) |
| POST | `/admin/events` | Create event |
| PATCH | `/admin/events/:id` | Update event |
| DELETE | `/admin/events/:id` | Delete event |
| GET | `/admin/shifts` | List shifts (date/role filter) |
| POST | `/admin/shifts` | Create shift |
| PATCH | `/admin/shifts/:id` | Update shift |
| DELETE | `/admin/shifts/:id` | Delete shift |
| GET | `/admin/schedule/:userId` | Get user schedule (admin bypass) |
| PUT | `/admin/schedule/:userId` | Replace user schedule |
| POST | `/admin/schedule/:userId` | Add event to schedule |
| DELETE | `/admin/schedule/:userId/:eventId` | Remove event from schedule |

### Architecture
- AdminService delegates to existing UsersService, EventsService, NotificationsService, ScheduleService
- New ShiftsService for shift CRUD with Firestore
- No existing controllers/services modified (except app.module.ts imports)
- TypeScript compiles cleanly

### Files changed (9 new, 1 modified)
- `backend/src/admin/admin.module.ts`
- `backend/src/admin/admin.controller.ts`
- `backend/src/admin/admin.service.ts`
- `backend/src/shifts/shifts.module.ts`
- `backend/src/shifts/shifts.service.ts`
- `backend/src/shifts/interfaces/shift.interface.ts`
- `backend/src/shifts/dto/create-shift.dto.ts`
- `backend/src/shifts/dto/update-shift.dto.ts`
- `backend/src/app.module.ts` (added ShiftsModule + AdminModule imports)