### PR TITLE
feat(admin): BFF-S3-06 — Admin Control Panel frontend

### DIFF
--- a/mobile/src/components/admin/AdminRoleBadge.tsx
+++ b/mobile/src/components/admin/AdminRoleBadge.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { useTheme } from '../../contexts/ThemeContext';
+
+interface AdminRoleBadgeProps {
+  role: string;
+  small?: boolean;
+}
+
+const ROLE_COLORS: Record<string, { bg: string; text: string }> = {
+  admin:     { bg: '#ef4444', text: '#fff' },
+  staff:     { bg: '#f97316', text: '#fff' },
+  artist:    { bg: '#a855f7', text: '#fff' },
+  director:  { bg: '#ec4899', text: '#fff' },
+  vendor:    { bg: '#14b8a6', text: '#fff' },
+  volunteer: { bg: '#3b82f6', text: '#fff' },
+  attendee:  { bg: '#6b7280', text: '#fff' },
+};
+
+export const AdminRoleBadge: React.FC<AdminRoleBadgeProps> = ({ role, small }) => {
+  const colors = ROLE_COLORS[role] ?? { bg: '#6b7280', text: '#fff' };
+  return (
+    <View style={[styles.badge, { backgroundColor: colors.bg }, small && styles.small]}>
+      <Text style={[styles.text, { color: colors.text }, small && styles.smallText]}>
+        {role.toUpperCase()}
+      </Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  badge: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 12,
+    alignSelf: 'flex-start',
+  },
+  small: {
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 8,
+  },
+  text: {
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+  },
+  smallText: {
+    fontSize: 9,
+  },
+});

--- a/mobile/src/components/admin/AdminSearchBar.tsx
+++ b/mobile/src/components/admin/AdminSearchBar.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { View, TextInput, StyleSheet } from 'react-native';
+import { useTheme } from '../../contexts/ThemeContext';
+
+interface AdminSearchBarProps {
+  value: string;
+  onChangeText: (text: string) => void;
+  placeholder?: string;
+}
+
+export const AdminSearchBar: React.FC<AdminSearchBarProps> = ({
+  value,
+  onChangeText,
+  placeholder = 'Search…',
+}) => {
+  const { theme } = useTheme();
+  return (
+    <View style={[styles.container, { backgroundColor: theme.card, borderColor: theme.border }]}>
+      <TextInput
+        style={[styles.input, { color: theme.text }]}
+        value={value}
+        onChangeText={onChangeText}
+        placeholder={placeholder}
+        placeholderTextColor={theme.muted}
+        autoCorrect={false}
+        autoCapitalize="none"
+        clearButtonMode="while-editing"
+        accessibilityLabel={placeholder}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    borderRadius: 10,
+    borderWidth: 1,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    marginBottom: 12,
+  },
+  input: {
+    fontSize: 15,
+    height: 28,
+  },
+});

--- a/mobile/src/components/admin/AdminStatCard.tsx
+++ b/mobile/src/components/admin/AdminStatCard.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useTheme } from '../../contexts/ThemeContext';
+
+interface AdminStatCardProps {
+  label: string;
+  value: string | number;
+  icon?: string;
+  accent?: string;
+}
+
+export const AdminStatCard: React.FC<AdminStatCardProps> = ({ label, value, icon, accent }) => {
+  const { theme } = useTheme();
+  return (
+    <View style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}>
+      {icon ? <Text style={styles.icon}>{icon}</Text> : null}
+      <Text style={[styles.value, { color: accent ?? theme.primary }]}>{value}</Text>
+      <Text style={[styles.label, { color: theme.muted }]}>{label}</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    flex: 1,
+    minWidth: 120,
+    padding: 16,
+    borderRadius: 12,
+    borderWidth: 1,
+    alignItems: 'center',
+    margin: 4,
+  },
+  icon: {
+    fontSize: 22,
+    marginBottom: 6,
+  },
+  value: {
+    fontSize: 26,
+    fontWeight: '700',
+    marginBottom: 2,
+  },
+  label: {
+    fontSize: 12,
+    fontWeight: '500',
+    textAlign: 'center',
+  },
+});

--- a/mobile/src/navigation/index.tsx
+++ b/mobile/src/navigation/index.tsx
@@ -13,7 +13,14 @@ import HomeScreen from '../screens/HomeScreen';
 import ScheduleScreen from '../screens/ScheduleScreen';
 import MapScreen from '../screens/MapScreen';
 import NotificationsScreen from '../screens/NotificationsScreen';
-import AdminNotificationsScreen from '../screens/AdminNotificationsScreen'; // Import the new screen
+import AdminNotificationsScreen from '../screens/admin/AdminNotificationsScreen';
+import { AdminDashboardScreen } from '../screens/admin/AdminDashboardScreen';
+import { AdminUsersScreen } from '../screens/admin/AdminUsersScreen';
+import { AdminUserDetailScreen } from '../screens/admin/AdminUserDetailScreen';
+import { AdminEventsScreen } from '../screens/admin/AdminEventsScreen';
+import { AdminEventEditScreen } from '../screens/admin/AdminEventEditScreen';
+import { AdminShiftsScreen } from '../screens/admin/AdminShiftsScreen';
+import { AdminScheduleScreen } from '../screens/admin/AdminScheduleScreen';
 import ProfileScreen from '../screens/ProfileScreen';
 import SettingsScreen from '../screens/SettingsScreen';
 import DebugScreen from '../screens/DebugScreen';
@@ -27,7 +34,15 @@ export type RootStackParamList = {
   Profile: undefined;
   Settings: undefined;
   Debug: undefined;
-  AdminNotifications: undefined; // Add the new screen to types
+  // Admin panel
+  AdminNotifications: undefined;
+  AdminPanel: undefined;
+  AdminUsers: undefined;
+  AdminUserDetail: { userId: string };
+  AdminEvents: undefined;
+  AdminEventEdit: { eventId?: string };
+  AdminShifts: undefined;
+  AdminSchedule: undefined;
 };
 
 export type AuthStackParamList = {
@@ -253,12 +268,42 @@ export default function Navigation() {
           <Stack.Screen
             name="AdminNotifications"
             component={AdminNotificationsScreen}
-            options={{
-              headerShown: true,
-              title: 'Send Notifications',
-              presentation: 'modal',
-              contentStyle: { backgroundColor },
-            }}
+            options={{ headerShown: true, title: 'Send Notification', presentation: 'modal', contentStyle: { backgroundColor } }}
+          />
+          <Stack.Screen
+            name="AdminPanel"
+            component={AdminDashboardScreen}
+            options={{ headerShown: true, title: '⚙️ Admin Panel', contentStyle: { backgroundColor } }}
+          />
+          <Stack.Screen
+            name="AdminUsers"
+            component={AdminUsersScreen}
+            options={{ headerShown: true, title: 'Users', contentStyle: { backgroundColor } }}
+          />
+          <Stack.Screen
+            name="AdminUserDetail"
+            component={AdminUserDetailScreen}
+            options={{ headerShown: true, title: 'User Detail', contentStyle: { backgroundColor } }}
+          />
+          <Stack.Screen
+            name="AdminEvents"
+            component={AdminEventsScreen}
+            options={{ headerShown: true, title: 'Events', contentStyle: { backgroundColor } }}
+          />
+          <Stack.Screen
+            name="AdminEventEdit"
+            component={AdminEventEditScreen}
+            options={{ headerShown: true, title: 'Edit Event', contentStyle: { backgroundColor } }}
+          />
+          <Stack.Screen
+            name="AdminShifts"
+            component={AdminShiftsScreen}
+            options={{ headerShown: true, title: 'Shifts', contentStyle: { backgroundColor } }}
+          />
+          <Stack.Screen
+            name="AdminSchedule"
+            component={AdminScheduleScreen}
+            options={{ headerShown: true, title: 'Schedule Editor', contentStyle: { backgroundColor } }}
           />
           <Stack.Screen
             name="Debug"

--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -161,6 +161,12 @@ const SettingsScreen = () => {
             title: 'Admin',
             items: [
               {
+                icon: 'grid-outline',
+                label: 'Admin Control Panel',
+                onPress: () => navigation.navigate('AdminPanel'),
+                description: 'Manage users, events, shifts, and schedule',
+              },
+              {
                 icon: 'megaphone-outline',
                 label: 'Send Notification to All Users',
                 onPress: () => navigation.navigate('AdminNotifications'),

--- a/mobile/src/screens/admin/AdminDashboardScreen.tsx
+++ b/mobile/src/screens/admin/AdminDashboardScreen.tsx
@@ -17,17 +17,6 @@ export const AdminDashboardScreen: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
 
-  // RBAC guard
-  if (user?.role !== 'admin') {
-    return (
-      <View style={[styles.center, { backgroundColor: theme.background }]}>
-        <Text style={[styles.denied, { color: theme.error ?? '#ef4444' }]}>
-          🚫 Admin access required
-        </Text>
-      </View>
-    );
-  }
-
   const fetchStats = useCallback(async () => {
     try {
       const data = await getAdminStats();
@@ -43,6 +32,17 @@ export const AdminDashboardScreen: React.FC = () => {
   useEffect(() => { fetchStats(); }, [fetchStats]);
 
   const onRefresh = () => { setRefreshing(true); fetchStats(); };
+
+  // RBAC guard — after all hooks
+  if (user?.role !== 'admin') {
+    return (
+      <View style={[styles.center, { backgroundColor: theme.background }]}>
+        <Text style={[styles.denied, { color: theme.error ?? '#ef4444' }]}>
+          🚫 Admin access required
+        </Text>
+      </View>
+    );
+  }
 
   if (loading) {
     return (

--- a/mobile/src/screens/admin/AdminDashboardScreen.tsx
+++ b/mobile/src/screens/admin/AdminDashboardScreen.tsx
@@ -1,0 +1,144 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View, Text, StyleSheet, ScrollView, TouchableOpacity,
+  RefreshControl, ActivityIndicator, Alert,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { useTheme } from '../../contexts/ThemeContext';
+import { useAuth } from '../../contexts/AuthContext';
+import { getAdminStats, AdminStats } from '../../services/adminService';
+import { AdminStatCard } from '../../components/admin/AdminStatCard';
+
+export const AdminDashboardScreen: React.FC = () => {
+  const { theme } = useTheme();
+  const { user } = useAuth();
+  const navigation = useNavigation<any>();
+  const [stats, setStats] = useState<AdminStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  // RBAC guard
+  if (user?.role !== 'admin') {
+    return (
+      <View style={[styles.center, { backgroundColor: theme.background }]}>
+        <Text style={[styles.denied, { color: theme.error ?? '#ef4444' }]}>
+          🚫 Admin access required
+        </Text>
+      </View>
+    );
+  }
+
+  const fetchStats = useCallback(async () => {
+    try {
+      const data = await getAdminStats();
+      setStats(data);
+    } catch (e: any) {
+      Alert.alert('Error', e.message || 'Failed to load stats');
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchStats(); }, [fetchStats]);
+
+  const onRefresh = () => { setRefreshing(true); fetchStats(); };
+
+  if (loading) {
+    return (
+      <View style={[styles.center, { backgroundColor: theme.background }]}>
+        <ActivityIndicator color={theme.primary} />
+      </View>
+    );
+  }
+
+  const roleEntries = Object.entries(stats?.usersByRole ?? {}).sort((a, b) => b[1] - a[1]);
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: theme.background }]}
+      contentContainerStyle={styles.content}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={theme.primary} />}
+    >
+      <Text style={[styles.header, { color: theme.text }]}>Admin Dashboard</Text>
+      <Text style={[styles.subtitle, { color: theme.muted }]}>
+        Big Fam Festival Control Panel
+      </Text>
+
+      {/* Stats row */}
+      <View style={styles.statsRow}>
+        <AdminStatCard label="Total Users" value={stats?.totalUsers ?? 0} icon="👥" />
+        <AdminStatCard label="Total Events" value={stats?.totalEvents ?? 0} icon="🎵" />
+      </View>
+      <View style={styles.statsRow}>
+        <AdminStatCard label="Notifications" value={stats?.totalNotifications ?? 0} icon="🔔" />
+        <AdminStatCard label="Roles" value={roleEntries.length} icon="🏷️" />
+      </View>
+
+      {/* Users by role */}
+      {roleEntries.length > 0 && (
+        <View style={[styles.section, { backgroundColor: theme.card, borderColor: theme.border }]}>
+          <Text style={[styles.sectionTitle, { color: theme.text }]}>Users by Role</Text>
+          {roleEntries.map(([role, count]) => (
+            <View key={role} style={styles.roleRow}>
+              <Text style={[styles.roleLabel, { color: theme.muted }]}>
+                {role.charAt(0).toUpperCase() + role.slice(1)}
+              </Text>
+              <Text style={[styles.roleCount, { color: theme.text }]}>{count}</Text>
+            </View>
+          ))}
+        </View>
+      )}
+
+      {/* Quick actions */}
+      <Text style={[styles.sectionTitle, { color: theme.text, marginTop: 20, marginBottom: 8 }]}>
+        Quick Actions
+      </Text>
+      <View style={styles.actionsGrid}>
+        {[
+          { label: '👤  Manage Users', screen: 'AdminUsers' },
+          { label: '🎵  Manage Events', screen: 'AdminEvents' },
+          { label: '🔔  Send Notification', screen: 'AdminNotifications' },
+          { label: '🗓️  View Shifts', screen: 'AdminShifts' },
+          { label: '📅  Edit Schedule', screen: 'AdminSchedule' },
+        ].map(({ label, screen }) => (
+          <TouchableOpacity
+            key={screen}
+            style={[styles.actionBtn, { backgroundColor: theme.card, borderColor: theme.border }]}
+            onPress={() => navigation.navigate(screen)}
+            accessibilityLabel={label}
+          >
+            <Text style={[styles.actionText, { color: theme.text }]}>{label}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  content: { padding: 16, paddingBottom: 40 },
+  center: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  denied: { fontSize: 16, fontWeight: '600' },
+  header: { fontSize: 26, fontWeight: '700', marginBottom: 4 },
+  subtitle: { fontSize: 14, marginBottom: 20 },
+  statsRow: { flexDirection: 'row', marginBottom: 0 },
+  section: {
+    borderRadius: 12,
+    borderWidth: 1,
+    padding: 16,
+    marginTop: 20,
+  },
+  sectionTitle: { fontSize: 16, fontWeight: '600', marginBottom: 12 },
+  roleRow: { flexDirection: 'row', justifyContent: 'space-between', paddingVertical: 6 },
+  roleLabel: { fontSize: 14 },
+  roleCount: { fontSize: 14, fontWeight: '600' },
+  actionsGrid: { gap: 10 },
+  actionBtn: {
+    padding: 16,
+    borderRadius: 12,
+    borderWidth: 1,
+  },
+  actionText: { fontSize: 15, fontWeight: '500' },
+});

--- a/mobile/src/screens/admin/AdminEventEditScreen.tsx
+++ b/mobile/src/screens/admin/AdminEventEditScreen.tsx
@@ -1,0 +1,178 @@
+import React, { useEffect, useState } from 'react';
+import {
+  View, Text, StyleSheet, ScrollView, TouchableOpacity,
+  TextInput, Alert, ActivityIndicator,
+} from 'react-native';
+import { useRoute, useNavigation, RouteProp } from '@react-navigation/native';
+import { useTheme } from '../../contexts/ThemeContext';
+import { createAdminEvent, updateAdminEvent, AdminEvent } from '../../services/adminService';
+import { fetchEvents } from "../../services/eventsService";
+
+type RouteParams = { eventId?: string };
+
+interface FormState {
+  name: string;
+  stage: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  description: string;
+  imageUrl: string;
+  genres: string;
+  artists: string;
+}
+
+const EMPTY_FORM: FormState = {
+  name: '', stage: '', date: '', startTime: '', endTime: '',
+  description: '', imageUrl: '', genres: '', artists: '',
+};
+
+export const AdminEventEditScreen: React.FC = () => {
+  const { theme } = useTheme();
+  const route = useRoute<RouteProp<Record<string, RouteParams>, string>>();
+  const navigation = useNavigation<any>();
+  const { eventId } = route.params ?? {};
+  const isEdit = !!eventId;
+
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [loading, setLoading] = useState(isEdit);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!isEdit) return;
+    (async () => {
+      try {
+        const { events } = await fetchEvents();
+        const ev = events.find((e: any) => e.id === eventId);
+        if (!ev) throw new Error('Event not found');
+        setForm({
+          name: ev.name ?? '',
+          stage: ev.stage ?? '',
+          date: ev.date ?? '',
+          startTime: ev.startTime ?? '',
+          endTime: ev.endTime ?? '',
+          description: ev.description ?? '',
+          imageUrl: ev.imageUrl ?? '',
+          genres: (ev.genres ?? []).join(', '),
+          artists: (ev.artists ?? []).join(', '),
+        });
+      } catch (e: any) {
+        Alert.alert('Error', e.message);
+        navigation.goBack();
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [eventId]);
+
+  const field = (key: keyof FormState) => ({
+    value: form[key],
+    onChangeText: (v: string) => setForm(prev => ({ ...prev, [key]: v })),
+  });
+
+  const handleSave = async () => {
+    if (!form.name.trim() || !form.stage.trim() || !form.date.trim()) {
+      Alert.alert('Validation', 'Name, stage, and date are required');
+      return;
+    }
+    setSaving(true);
+    try {
+      const dto = {
+        name: form.name.trim(),
+        stage: form.stage.trim(),
+        date: form.date.trim(),
+        startTime: form.startTime.trim(),
+        endTime: form.endTime.trim(),
+        description: form.description.trim() || undefined,
+        imageUrl: form.imageUrl.trim() || undefined,
+        genres: form.genres ? form.genres.split(',').map(g => g.trim()).filter(Boolean) : undefined,
+        artists: form.artists ? form.artists.split(',').map(a => a.trim()).filter(Boolean) : undefined,
+      };
+      if (isEdit) {
+        await updateAdminEvent(eventId!, dto);
+      } else {
+        await createAdminEvent(dto as any);
+      }
+      Alert.alert('Success', isEdit ? 'Event updated' : 'Event created');
+      navigation.goBack();
+    } catch (e: any) {
+      Alert.alert('Error', e.message || 'Failed to save event');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <View style={[styles.center, { backgroundColor: theme.background }]}>
+        <ActivityIndicator color={theme.primary} />
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: theme.background }]}
+      contentContainerStyle={styles.content}
+      keyboardShouldPersistTaps="handled"
+    >
+      <Text style={[styles.title, { color: theme.text }]}>{isEdit ? 'Edit Event' : 'New Event'}</Text>
+
+      {[
+        { label: 'Event Name *', key: 'name' as const, placeholder: 'e.g. DJ Set — Main Stage' },
+        { label: 'Stage *', key: 'stage' as const, placeholder: 'e.g. Main Stage' },
+        { label: 'Date * (YYYY-MM-DD)', key: 'date' as const, placeholder: '2025-08-15' },
+        { label: 'Start Time (HH:MM)', key: 'startTime' as const, placeholder: '14:00' },
+        { label: 'End Time (HH:MM)', key: 'endTime' as const, placeholder: '16:00' },
+        { label: 'Description', key: 'description' as const, placeholder: 'Optional description' },
+        { label: 'Image URL', key: 'imageUrl' as const, placeholder: 'https://…' },
+        { label: 'Genres (comma-separated)', key: 'genres' as const, placeholder: 'House, Techno' },
+        { label: 'Artists (comma-separated)', key: 'artists' as const, placeholder: 'DJ A, DJ B' },
+      ].map(({ label, key, placeholder }) => (
+        <View key={key}>
+          <Text style={[styles.label, { color: theme.muted }]}>{label}</Text>
+          <TextInput
+            style={[styles.input, { backgroundColor: theme.card, color: theme.text, borderColor: theme.border }]}
+            placeholder={placeholder}
+            placeholderTextColor={theme.muted}
+            {...field(key)}
+            accessibilityLabel={label}
+          />
+        </View>
+      ))}
+
+      <TouchableOpacity
+        style={[styles.saveBtn, { backgroundColor: theme.primary }, saving && { opacity: 0.7 }]}
+        onPress={handleSave}
+        disabled={saving}
+        accessibilityLabel={isEdit ? 'Save event changes' : 'Create event'}
+      >
+        {saving
+          ? <ActivityIndicator color="#fff" />
+          : <Text style={styles.saveBtnText}>{isEdit ? 'Save Changes' : 'Create Event'}</Text>
+        }
+      </TouchableOpacity>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  content: { padding: 16, paddingBottom: 40 },
+  center: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 22, fontWeight: '700', marginBottom: 20 },
+  label: { fontSize: 13, marginTop: 14, marginBottom: 4 },
+  input: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 10,
+    fontSize: 15,
+  },
+  saveBtn: {
+    marginTop: 28,
+    padding: 16,
+    borderRadius: 12,
+    alignItems: 'center',
+  },
+  saveBtnText: { color: '#fff', fontSize: 16, fontWeight: '700' },
+});

--- a/mobile/src/screens/admin/AdminEventsScreen.tsx
+++ b/mobile/src/screens/admin/AdminEventsScreen.tsx
@@ -1,0 +1,154 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View, Text, FlatList, StyleSheet, TouchableOpacity,
+  RefreshControl, ActivityIndicator, Alert,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { useTheme } from '../../contexts/ThemeContext';
+import { deleteAdminEvent, AdminEvent } from '../../services/adminService';
+import { AdminSearchBar } from '../../components/admin/AdminSearchBar';
+import { fetchEvents as fetchEventsFromService } from "../../services/eventsService";
+
+export const AdminEventsScreen: React.FC = () => {
+  const { theme } = useTheme();
+  const navigation = useNavigation<any>();
+  const [events, setEvents] = useState<AdminEvent[]>([]);
+  const [filtered, setFiltered] = useState<AdminEvent[]>([]);
+  const [search, setSearch] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const fetchEvents = useCallback(async () => {
+    try {
+      const { events: data } = await fetchEventsFromService();
+      setEvents(data as any);
+      setFiltered(data as any);
+    } catch (e: any) {
+      Alert.alert('Error', e.message || 'Failed to load events');
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchEvents(); }, [fetchEvents]);
+
+  useEffect(() => {
+    const q = search.toLowerCase();
+    setFiltered(events.filter(e =>
+      e.name?.toLowerCase().includes(q) ||
+      e.stage?.toLowerCase().includes(q)
+    ));
+  }, [search, events]);
+
+  const onRefresh = () => { setRefreshing(true); fetchEvents(); };
+
+  const handleDelete = (event: AdminEvent) => {
+    Alert.alert(
+      'Delete Event',
+      `Delete "${event.name}"? This cannot be undone.`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await deleteAdminEvent(event.id);
+              setEvents(prev => prev.filter(e => e.id !== event.id));
+            } catch (e: any) {
+              Alert.alert('Error', e.message || 'Failed to delete event');
+            }
+          },
+        },
+      ]
+    );
+  };
+
+  const renderItem = ({ item }: { item: AdminEvent }) => (
+    <View style={[styles.row, { backgroundColor: theme.card, borderColor: theme.border }]}>
+      <TouchableOpacity
+        style={styles.rowMain}
+        onPress={() => navigation.navigate('AdminEventEdit', { eventId: item.id })}
+        accessibilityLabel={`Edit event ${item.name}`}
+      >
+        <Text style={[styles.name, { color: theme.text }]} numberOfLines={1}>{item.name}</Text>
+        <Text style={[styles.meta, { color: theme.muted }]}>
+          {item.stage} • {item.date} {item.startTime}–{item.endTime}
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        onPress={() => handleDelete(item)}
+        style={[styles.deleteBtn, { borderColor: '#ef4444' + '44' }]}
+        accessibilityLabel={`Delete event ${item.name}`}
+      >
+        <Text style={styles.deleteText}>✕</Text>
+      </TouchableOpacity>
+    </View>
+  );
+
+  return (
+    <View style={[styles.container, { backgroundColor: theme.background }]}>
+      <View style={styles.headerRow}>
+        <View style={styles.searchWrap}>
+          <AdminSearchBar value={search} onChangeText={setSearch} placeholder="Search events…" />
+        </View>
+        <TouchableOpacity
+          style={[styles.addBtn, { backgroundColor: theme.primary }]}
+          onPress={() => navigation.navigate('AdminEventEdit', {})}
+          accessibilityLabel="Create new event"
+        >
+          <Text style={styles.addText}>+ New</Text>
+        </TouchableOpacity>
+      </View>
+
+      {loading ? (
+        <View style={styles.center}>
+          <ActivityIndicator color={theme.primary} />
+        </View>
+      ) : (
+        <FlatList
+          data={filtered}
+          keyExtractor={e => e.id}
+          renderItem={renderItem}
+          refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={theme.primary} />}
+          contentContainerStyle={styles.list}
+          ListEmptyComponent={
+            <View style={styles.center}>
+              <Text style={[styles.empty, { color: theme.muted }]}>No events found</Text>
+            </View>
+          }
+        />
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  headerRow: { flexDirection: 'row', padding: 16, paddingBottom: 0, alignItems: 'flex-start', gap: 8 },
+  searchWrap: { flex: 1 },
+  addBtn: { paddingHorizontal: 14, paddingVertical: 10, borderRadius: 10, marginTop: 0 },
+  addText: { color: '#fff', fontWeight: '700', fontSize: 13 },
+  list: { padding: 16, paddingTop: 8 },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 10,
+    borderWidth: 1,
+    marginBottom: 8,
+    overflow: 'hidden',
+  },
+  rowMain: { flex: 1, padding: 12 },
+  name: { fontSize: 14, fontWeight: '600', marginBottom: 3 },
+  meta: { fontSize: 12 },
+  deleteBtn: {
+    padding: 16,
+    borderLeftWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  deleteText: { color: '#ef4444', fontSize: 16 },
+  center: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 40 },
+  empty: { fontSize: 14 },
+});

--- a/mobile/src/screens/admin/AdminEventsScreen.tsx
+++ b/mobile/src/screens/admin/AdminEventsScreen.tsx
@@ -5,9 +5,8 @@ import {
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useTheme } from '../../contexts/ThemeContext';
-import { deleteAdminEvent, AdminEvent } from '../../services/adminService';
+import { deleteAdminEvent, listAdminEvents, AdminEvent } from '../../services/adminService';
 import { AdminSearchBar } from '../../components/admin/AdminSearchBar';
-import { fetchEvents as fetchEventsFromService } from "../../services/eventsService";
 
 export const AdminEventsScreen: React.FC = () => {
   const { theme } = useTheme();
@@ -20,7 +19,7 @@ export const AdminEventsScreen: React.FC = () => {
 
   const fetchEvents = useCallback(async () => {
     try {
-      const { events: data } = await fetchEventsFromService();
+      const data = await listAdminEvents();
       setEvents(data as any);
       setFiltered(data as any);
     } catch (e: any) {

--- a/mobile/src/screens/admin/AdminNotificationsScreen.tsx
+++ b/mobile/src/screens/admin/AdminNotificationsScreen.tsx
@@ -1,0 +1,191 @@
+import React, { useState } from 'react';
+import {
+  View, Text, StyleSheet, ScrollView, TouchableOpacity,
+  TextInput, Alert, ActivityIndicator,
+} from 'react-native';
+import { useTheme } from '../../contexts/ThemeContext';
+import { api } from '../../services/api';
+import { getIdToken } from '../../services/firebaseAuthService';
+
+const USER_GROUPS = ['all', 'attendee', 'staff', 'artist', 'director', 'vendor', 'volunteer', 'admin'];
+
+export const AdminNotificationsScreen: React.FC = () => {
+  const { theme } = useTheme();
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [selectedGroup, setSelectedGroup] = useState('all');
+  const [sending, setSending] = useState(false);
+  const [lastSent, setLastSent] = useState<{ title: string; group: string; at: string } | null>(null);
+
+  const handleSend = async () => {
+    if (!title.trim() || !body.trim()) {
+      Alert.alert('Required', 'Title and message body are required');
+      return;
+    }
+    Alert.alert(
+      'Confirm Send',
+      `Send "${title}" to group: ${selectedGroup}?`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Send',
+          onPress: async () => {
+            setSending(true);
+            try {
+              const token = await getIdToken();
+              await api.post(
+                '/notifications/send',
+                {
+                  title: title.trim(),
+                  body: body.trim(),
+                  targetGroup: selectedGroup === 'all' ? undefined : selectedGroup,
+                },
+                { headers: { Authorization: `Bearer ${token}` } }
+              );
+              setLastSent({ title: title.trim(), group: selectedGroup, at: new Date().toLocaleTimeString() });
+              setTitle('');
+              setBody('');
+              Alert.alert('Sent ✓', `Notification sent to "${selectedGroup}"`);
+            } catch (e: any) {
+              Alert.alert('Error', e.response?.data?.message || e.message || 'Failed to send');
+            } finally {
+              setSending(false);
+            }
+          },
+        },
+      ]
+    );
+  };
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: theme.background }]}
+      contentContainerStyle={styles.content}
+      keyboardShouldPersistTaps="handled"
+    >
+      <Text style={[styles.header, { color: theme.text }]}>Send Notification</Text>
+      <Text style={[styles.subtitle, { color: theme.muted }]}>
+        Target a group or send to all attendees
+      </Text>
+
+      {/* Group selector */}
+      <Text style={[styles.label, { color: theme.muted }]}>Target Group</Text>
+      <View style={styles.groupGrid}>
+        {USER_GROUPS.map(g => (
+          <TouchableOpacity
+            key={g}
+            style={[
+              styles.groupChip,
+              {
+                borderColor: selectedGroup === g ? theme.primary : theme.border,
+                backgroundColor: selectedGroup === g ? theme.primary + '22' : theme.card,
+              },
+            ]}
+            onPress={() => setSelectedGroup(g)}
+            accessibilityLabel={`Target group ${g}`}
+          >
+            <Text style={[styles.groupChipText, { color: selectedGroup === g ? theme.primary : theme.text }]}>
+              {g}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      {/* Title */}
+      <Text style={[styles.label, { color: theme.muted }]}>Title *</Text>
+      <TextInput
+        style={[styles.input, { backgroundColor: theme.card, color: theme.text, borderColor: theme.border }]}
+        value={title}
+        onChangeText={setTitle}
+        placeholder="Notification title"
+        placeholderTextColor={theme.muted}
+        maxLength={100}
+        accessibilityLabel="Notification title"
+      />
+      <Text style={[styles.charCount, { color: theme.muted }]}>{title.length}/100</Text>
+
+      {/* Body */}
+      <Text style={[styles.label, { color: theme.muted }]}>Message *</Text>
+      <TextInput
+        style={[styles.textarea, { backgroundColor: theme.card, color: theme.text, borderColor: theme.border }]}
+        value={body}
+        onChangeText={setBody}
+        placeholder="Notification body"
+        placeholderTextColor={theme.muted}
+        multiline
+        numberOfLines={4}
+        maxLength={500}
+        accessibilityLabel="Notification body"
+      />
+      <Text style={[styles.charCount, { color: theme.muted }]}>{body.length}/500</Text>
+
+      {/* Last sent banner */}
+      {lastSent && (
+        <View style={[styles.sentBanner, { backgroundColor: '#10b981' + '22', borderColor: '#10b981' }]}>
+          <Text style={[styles.sentText, { color: '#10b981' }]}>
+            ✓ Sent "{lastSent.title}" → {lastSent.group} at {lastSent.at}
+          </Text>
+        </View>
+      )}
+
+      <TouchableOpacity
+        style={[styles.sendBtn, { backgroundColor: theme.primary }, sending && { opacity: 0.7 }]}
+        onPress={handleSend}
+        disabled={sending}
+        accessibilityLabel="Send notification"
+      >
+        {sending
+          ? <ActivityIndicator color="#fff" />
+          : <Text style={styles.sendBtnText}>🔔  Send Notification</Text>
+        }
+      </TouchableOpacity>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  content: { padding: 16, paddingBottom: 40 },
+  header: { fontSize: 24, fontWeight: '700', marginBottom: 4 },
+  subtitle: { fontSize: 14, marginBottom: 20 },
+  label: { fontSize: 13, marginTop: 16, marginBottom: 6 },
+  groupGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+  groupChip: {
+    paddingHorizontal: 14,
+    paddingVertical: 7,
+    borderRadius: 16,
+    borderWidth: 1.5,
+  },
+  groupChipText: { fontSize: 13, fontWeight: '500' },
+  input: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 10,
+    fontSize: 15,
+  },
+  textarea: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 10,
+    fontSize: 15,
+    height: 100,
+    textAlignVertical: 'top',
+  },
+  charCount: { fontSize: 11, textAlign: 'right', marginTop: 2 },
+  sentBanner: {
+    marginTop: 16,
+    padding: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+  },
+  sentText: { fontSize: 13, fontWeight: '500' },
+  sendBtn: {
+    marginTop: 24,
+    padding: 16,
+    borderRadius: 12,
+    alignItems: 'center',
+  },
+  sendBtnText: { color: '#fff', fontSize: 16, fontWeight: '700' },
+});
+
+export default AdminNotificationsScreen;

--- a/mobile/src/screens/admin/AdminNotificationsScreen.tsx
+++ b/mobile/src/screens/admin/AdminNotificationsScreen.tsx
@@ -4,8 +4,7 @@ import {
   TextInput, Alert, ActivityIndicator,
 } from 'react-native';
 import { useTheme } from '../../contexts/ThemeContext';
-import { api } from '../../services/api';
-import { getIdToken } from '../../services/firebaseAuthService';
+import { sendAdminNotification } from '../../services/adminService';
 
 const USER_GROUPS = ['all', 'attendee', 'staff', 'artist', 'director', 'vendor', 'volunteer', 'admin'];
 
@@ -32,16 +31,11 @@ export const AdminNotificationsScreen: React.FC = () => {
           onPress: async () => {
             setSending(true);
             try {
-              const token = await getIdToken();
-              await api.post(
-                '/notifications/send',
-                {
-                  title: title.trim(),
-                  body: body.trim(),
-                  targetGroup: selectedGroup === 'all' ? undefined : selectedGroup,
-                },
-                { headers: { Authorization: `Bearer ${token}` } }
-              );
+              await sendAdminNotification({
+                title: title.trim(),
+                body: body.trim(),
+                targetGroup: selectedGroup === 'all' ? undefined : selectedGroup,
+              });
               setLastSent({ title: title.trim(), group: selectedGroup, at: new Date().toLocaleTimeString() });
               setTitle('');
               setBody('');

--- a/mobile/src/screens/admin/AdminScheduleScreen.tsx
+++ b/mobile/src/screens/admin/AdminScheduleScreen.tsx
@@ -1,0 +1,162 @@
+/**
+ * AdminScheduleScreen — admin-only editable schedule view.
+ * Shows all events across all days. Tap any event to edit it in AdminEventEdit.
+ * This reuses the schedule layout but removes all user personalization — admin sees everything.
+ */
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View, Text, FlatList, StyleSheet, TouchableOpacity,
+  RefreshControl, ActivityIndicator, SectionList,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { useTheme } from '../../contexts/ThemeContext';
+import { fetchEvents as fetchEventsFromService } from "../../services/eventsService";
+import { AdminEvent } from '../../services/adminService';
+
+const STAGE_COLORS: Record<string, string> = {
+  'Main Stage': '#f59e0b',
+  'Stage 2':    '#3b82f6',
+  'Stage 3':    '#8b5cf6',
+  'Stage 4':    '#10b981',
+  'Tent':       '#ec4899',
+};
+
+export const AdminScheduleScreen: React.FC = () => {
+  const { theme } = useTheme();
+  const navigation = useNavigation<any>();
+  const [events, setEvents] = useState<AdminEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const fetchEvents = useCallback(async () => {
+    try {
+      const { events: data } = await fetchEventsFromService();
+      setEvents(data as any);
+    } catch {
+      // silent
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchEvents(); }, [fetchEvents]);
+
+  const onRefresh = () => { setRefreshing(true); fetchEvents(); };
+
+  // Group by date
+  const grouped = events.reduce<Record<string, AdminEvent[]>>((acc, ev) => {
+    const key = ev.date ?? 'Unknown';
+    (acc[key] = acc[key] ?? []).push(ev);
+    return acc;
+  }, {});
+
+  const sections = Object.keys(grouped)
+    .sort()
+    .map(date => ({
+      title: date,
+      data: grouped[date].sort((a, b) => (a.startTime ?? '').localeCompare(b.startTime ?? '')),
+    }));
+
+  const stageColor = (stage: string) =>
+    STAGE_COLORS[stage] ?? theme.primary;
+
+  if (loading) {
+    return (
+      <View style={[styles.center, { backgroundColor: theme.background }]}>
+        <ActivityIndicator color={theme.primary} />
+      </View>
+    );
+  }
+
+  return (
+    <SectionList
+      style={[styles.container, { backgroundColor: theme.background }]}
+      sections={sections}
+      keyExtractor={ev => ev.id}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={theme.primary} />}
+      contentContainerStyle={styles.content}
+      ListHeaderComponent={
+        <View style={styles.headerBar}>
+          <Text style={[styles.headerTitle, { color: theme.text }]}>Schedule Editor</Text>
+          <TouchableOpacity
+            style={[styles.newBtn, { backgroundColor: theme.primary }]}
+            onPress={() => navigation.navigate('AdminEventEdit', {})}
+            accessibilityLabel="Create new event"
+          >
+            <Text style={styles.newBtnText}>+ Event</Text>
+          </TouchableOpacity>
+        </View>
+      }
+      renderSectionHeader={({ section }) => (
+        <Text style={[styles.dateHeader, { color: theme.primary, backgroundColor: theme.background }]}>
+          {section.title}
+        </Text>
+      )}
+      renderItem={({ item }) => (
+        <TouchableOpacity
+          style={[styles.eventRow, { backgroundColor: theme.card, borderColor: theme.border }]}
+          onPress={() => navigation.navigate('AdminEventEdit', { eventId: item.id })}
+          accessibilityLabel={`Edit ${item.name}`}
+        >
+          <View style={[styles.stageTag, { backgroundColor: stageColor(item.stage) + '33', borderColor: stageColor(item.stage) }]}>
+            <Text style={[styles.stageText, { color: stageColor(item.stage) }]} numberOfLines={1}>
+              {item.stage}
+            </Text>
+          </View>
+          <View style={styles.eventInfo}>
+            <Text style={[styles.eventName, { color: theme.text }]} numberOfLines={1}>{item.name}</Text>
+            <Text style={[styles.eventTime, { color: theme.muted }]}>
+              {item.startTime}–{item.endTime}
+            </Text>
+          </View>
+          <Text style={[styles.editHint, { color: theme.primary }]}>Edit ›</Text>
+        </TouchableOpacity>
+      )}
+      ListEmptyComponent={
+        <View style={styles.center}>
+          <Text style={[styles.empty, { color: theme.muted }]}>No events</Text>
+        </View>
+      }
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  content: { padding: 16, paddingBottom: 40 },
+  center: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 40 },
+  headerBar: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  headerTitle: { fontSize: 22, fontWeight: '700' },
+  newBtn: { paddingHorizontal: 14, paddingVertical: 8, borderRadius: 8 },
+  newBtnText: { color: '#fff', fontWeight: '700', fontSize: 13 },
+  dateHeader: { fontSize: 13, fontWeight: '700', paddingVertical: 8, letterSpacing: 0.5 },
+  eventRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 10,
+    borderWidth: 1,
+    padding: 12,
+    marginBottom: 6,
+    gap: 10,
+  },
+  stageTag: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 6,
+    borderWidth: 1,
+    minWidth: 60,
+    alignItems: 'center',
+  },
+  stageText: { fontSize: 10, fontWeight: '700' },
+  eventInfo: { flex: 1 },
+  eventName: { fontSize: 14, fontWeight: '600', marginBottom: 2 },
+  eventTime: { fontSize: 12 },
+  editHint: { fontSize: 13, fontWeight: '600' },
+  empty: { fontSize: 14 },
+});

--- a/mobile/src/screens/admin/AdminShiftsScreen.tsx
+++ b/mobile/src/screens/admin/AdminShiftsScreen.tsx
@@ -1,0 +1,248 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View, Text, FlatList, StyleSheet, TouchableOpacity,
+  RefreshControl, ActivityIndicator, Alert, TextInput, Modal, ScrollView,
+} from 'react-native';
+import { useTheme } from '../../contexts/ThemeContext';
+import {
+  listAdminShifts, createAdminShift, deleteAdminShift, AdminShift,
+} from '../../services/adminService';
+
+const EMPTY_SHIFT = {
+  userId: '', userName: '', role: 'staff',
+  date: '', startTime: '', endTime: '', location: '', stage: '', notes: '',
+};
+
+export const AdminShiftsScreen: React.FC = () => {
+  const { theme } = useTheme();
+  const [shifts, setShifts] = useState<AdminShift[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [dateFilter, setDateFilter] = useState('');
+  const [roleFilter, setRoleFilter] = useState('');
+  const [showCreate, setShowCreate] = useState(false);
+  const [form, setForm] = useState({ ...EMPTY_SHIFT });
+  const [saving, setSaving] = useState(false);
+
+  const fetchShifts = useCallback(async () => {
+    try {
+      const data = await listAdminShifts({
+        date: dateFilter || undefined,
+        role: roleFilter || undefined,
+      });
+      setShifts(data);
+    } catch (e: any) {
+      Alert.alert('Error', e.message || 'Failed to load shifts');
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [dateFilter, roleFilter]);
+
+  useEffect(() => { fetchShifts(); }, [fetchShifts]);
+
+  const onRefresh = () => { setRefreshing(true); fetchShifts(); };
+
+  const handleDelete = (shift: AdminShift) => {
+    Alert.alert('Delete Shift', `Delete ${shift.userName}'s shift on ${shift.date}?`, [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Delete', style: 'destructive',
+        onPress: async () => {
+          try {
+            await deleteAdminShift(shift.id);
+            setShifts(prev => prev.filter(s => s.id !== shift.id));
+          } catch (e: any) {
+            Alert.alert('Error', e.message);
+          }
+        },
+      },
+    ]);
+  };
+
+  const handleCreate = async () => {
+    if (!form.userName || !form.date || !form.location) {
+      Alert.alert('Validation', 'Name, date, and location required');
+      return;
+    }
+    setSaving(true);
+    try {
+      const created = await createAdminShift(form);
+      setShifts(prev => [created, ...prev]);
+      setShowCreate(false);
+      setForm({ ...EMPTY_SHIFT });
+    } catch (e: any) {
+      Alert.alert('Error', e.message || 'Failed to create shift');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Group by date
+  const grouped = shifts.reduce<Record<string, AdminShift[]>>((acc, s) => {
+    (acc[s.date] = acc[s.date] ?? []).push(s);
+    return acc;
+  }, {});
+  const dates = Object.keys(grouped).sort();
+
+  return (
+    <View style={[styles.container, { backgroundColor: theme.background }]}>
+      {/* Filters */}
+      <View style={styles.filters}>
+        <TextInput
+          style={[styles.filterInput, { backgroundColor: theme.card, color: theme.text, borderColor: theme.border }]}
+          value={dateFilter}
+          onChangeText={setDateFilter}
+          placeholder="Date (YYYY-MM-DD)"
+          placeholderTextColor={theme.muted}
+          accessibilityLabel="Filter by date"
+        />
+        <TextInput
+          style={[styles.filterInput, { backgroundColor: theme.card, color: theme.text, borderColor: theme.border }]}
+          value={roleFilter}
+          onChangeText={setRoleFilter}
+          placeholder="Role filter"
+          placeholderTextColor={theme.muted}
+          accessibilityLabel="Filter by role"
+        />
+        <TouchableOpacity
+          style={[styles.addBtn, { backgroundColor: theme.primary }]}
+          onPress={() => setShowCreate(true)}
+          accessibilityLabel="Create shift"
+        >
+          <Text style={styles.addText}>+ Shift</Text>
+        </TouchableOpacity>
+      </View>
+
+      {loading ? (
+        <View style={styles.center}><ActivityIndicator color={theme.primary} /></View>
+      ) : (
+        <FlatList
+          data={dates}
+          keyExtractor={d => d}
+          refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={theme.primary} />}
+          contentContainerStyle={styles.list}
+          ListEmptyComponent={
+            <View style={styles.center}>
+              <Text style={[styles.empty, { color: theme.muted }]}>No shifts found</Text>
+            </View>
+          }
+          renderItem={({ item: date }) => (
+            <View>
+              <Text style={[styles.dateHeader, { color: theme.primary }]}>{date}</Text>
+              {grouped[date].map(shift => (
+                <View key={shift.id} style={[styles.shiftRow, { backgroundColor: theme.card, borderColor: theme.border }]}>
+                  <View style={styles.shiftInfo}>
+                    <Text style={[styles.shiftName, { color: theme.text }]}>{shift.userName}</Text>
+                    <Text style={[styles.shiftMeta, { color: theme.muted }]}>
+                      {shift.role} • {shift.startTime}–{shift.endTime} • {shift.location}
+                      {shift.stage ? ` (${shift.stage})` : ''}
+                    </Text>
+                    {shift.notes ? (
+                      <Text style={[styles.shiftNotes, { color: theme.muted }]}>{shift.notes}</Text>
+                    ) : null}
+                  </View>
+                  <TouchableOpacity
+                    onPress={() => handleDelete(shift)}
+                    accessibilityLabel={`Delete shift for ${shift.userName}`}
+                  >
+                    <Text style={styles.deleteText}>✕</Text>
+                  </TouchableOpacity>
+                </View>
+              ))}
+            </View>
+          )}
+        />
+      )}
+
+      {/* Create shift modal */}
+      <Modal visible={showCreate} animationType="slide" presentationStyle="pageSheet">
+        <ScrollView
+          style={[styles.modal, { backgroundColor: theme.background }]}
+          contentContainerStyle={styles.modalContent}
+          keyboardShouldPersistTaps="handled"
+        >
+          <Text style={[styles.modalTitle, { color: theme.text }]}>New Shift</Text>
+          {[
+            { label: 'Staff Name *', key: 'userName', placeholder: 'Full name' },
+            { label: 'User ID', key: 'userId', placeholder: 'Firebase UID (optional)' },
+            { label: 'Role', key: 'role', placeholder: 'staff / volunteer / etc.' },
+            { label: 'Date * (YYYY-MM-DD)', key: 'date', placeholder: '2025-08-15' },
+            { label: 'Start Time (HH:MM)', key: 'startTime', placeholder: '08:00' },
+            { label: 'End Time (HH:MM)', key: 'endTime', placeholder: '16:00' },
+            { label: 'Location *', key: 'location', placeholder: 'Main Gate, Stage 2, etc.' },
+            { label: 'Stage', key: 'stage', placeholder: 'Optional' },
+            { label: 'Notes', key: 'notes', placeholder: 'Any notes' },
+          ].map(({ label, key, placeholder }) => (
+            <View key={key}>
+              <Text style={[styles.label, { color: theme.muted }]}>{label}</Text>
+              <TextInput
+                style={[styles.input, { backgroundColor: theme.card, color: theme.text, borderColor: theme.border }]}
+                value={(form as any)[key]}
+                onChangeText={v => setForm(prev => ({ ...prev, [key]: v }))}
+                placeholder={placeholder}
+                placeholderTextColor={theme.muted}
+                accessibilityLabel={label}
+              />
+            </View>
+          ))}
+
+          <View style={styles.modalActions}>
+            <TouchableOpacity
+              onPress={() => { setShowCreate(false); setForm({ ...EMPTY_SHIFT }); }}
+              style={[styles.cancelBtn, { borderColor: theme.border }]}
+              accessibilityLabel="Cancel"
+            >
+              <Text style={[styles.cancelText, { color: theme.text }]}>Cancel</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={handleCreate}
+              style={[styles.saveBtn, { backgroundColor: theme.primary }, saving && { opacity: 0.7 }]}
+              disabled={saving}
+              accessibilityLabel="Save shift"
+            >
+              {saving ? <ActivityIndicator color="#fff" /> : <Text style={styles.saveBtnText}>Create Shift</Text>}
+            </TouchableOpacity>
+          </View>
+        </ScrollView>
+      </Modal>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  filters: { flexDirection: 'row', padding: 12, gap: 6, alignItems: 'center' },
+  filterInput: {
+    flex: 1, borderWidth: 1, borderRadius: 8, padding: 8, fontSize: 13,
+  },
+  addBtn: { paddingHorizontal: 12, paddingVertical: 10, borderRadius: 8 },
+  addText: { color: '#fff', fontWeight: '700', fontSize: 13 },
+  list: { padding: 16, paddingTop: 4, paddingBottom: 40 },
+  dateHeader: { fontSize: 13, fontWeight: '700', marginTop: 12, marginBottom: 6, letterSpacing: 0.5 },
+  shiftRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 10,
+    borderWidth: 1,
+    padding: 12,
+    marginBottom: 6,
+  },
+  shiftInfo: { flex: 1 },
+  shiftName: { fontSize: 14, fontWeight: '600', marginBottom: 2 },
+  shiftMeta: { fontSize: 12 },
+  shiftNotes: { fontSize: 11, marginTop: 2, fontStyle: 'italic' },
+  deleteText: { color: '#ef4444', fontSize: 18, paddingLeft: 12 },
+  center: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 40 },
+  empty: { fontSize: 14 },
+  modal: { flex: 1 },
+  modalContent: { padding: 24, paddingBottom: 40 },
+  modalTitle: { fontSize: 22, fontWeight: '700', marginBottom: 16 },
+  label: { fontSize: 13, marginTop: 12, marginBottom: 4 },
+  input: { borderWidth: 1, borderRadius: 8, padding: 10, fontSize: 15 },
+  modalActions: { flexDirection: 'row', gap: 12, marginTop: 24 },
+  cancelBtn: { flex: 1, padding: 14, borderRadius: 10, borderWidth: 1, alignItems: 'center' },
+  cancelText: { fontSize: 15, fontWeight: '600' },
+  saveBtn: { flex: 1, padding: 14, borderRadius: 10, alignItems: 'center' },
+  saveBtnText: { color: '#fff', fontSize: 15, fontWeight: '700' },
+});

--- a/mobile/src/screens/admin/AdminUserDetailScreen.tsx
+++ b/mobile/src/screens/admin/AdminUserDetailScreen.tsx
@@ -1,0 +1,205 @@
+import React, { useEffect, useState } from 'react';
+import {
+  View, Text, StyleSheet, ScrollView, TouchableOpacity,
+  TextInput, Alert, ActivityIndicator, Switch,
+} from 'react-native';
+import { useRoute, useNavigation, RouteProp } from '@react-navigation/native';
+import { useTheme } from '../../contexts/ThemeContext';
+import { getAdminUser, updateAdminUser, AdminUser } from '../../services/adminService';
+import { AdminRoleBadge } from '../../components/admin/AdminRoleBadge';
+
+type RouteParams = { userId: string };
+
+const ALL_ROLES = ['admin', 'staff', 'artist', 'director', 'vendor', 'volunteer', 'attendee'];
+
+export const AdminUserDetailScreen: React.FC = () => {
+  const { theme } = useTheme();
+  const route = useRoute<RouteProp<Record<string, RouteParams>, string>>();
+  const navigation = useNavigation<any>();
+  const { userId } = route.params;
+
+  const [user, setUser] = useState<AdminUser | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  // Editable fields
+  const [name, setName] = useState('');
+  const [phone, setPhone] = useState('');
+  const [role, setRole] = useState('');
+  const [notificationsEnabled, setNotificationsEnabled] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const u = await getAdminUser(userId);
+        setUser(u);
+        setName(u.name ?? '');
+        setPhone(u.phone ?? '');
+        setRole(u.role ?? 'attendee');
+        setNotificationsEnabled(u.notificationsEnabled ?? false);
+      } catch (e: any) {
+        Alert.alert('Error', e.message || 'Failed to load user');
+        navigation.goBack();
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [userId]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await updateAdminUser(userId, { name, phone, role, notificationsEnabled });
+      Alert.alert('Saved', 'User updated successfully');
+      navigation.goBack();
+    } catch (e: any) {
+      Alert.alert('Error', e.message || 'Failed to save user');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <View style={[styles.center, { backgroundColor: theme.background }]}>
+        <ActivityIndicator color={theme.primary} />
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: theme.background }]}
+      contentContainerStyle={styles.content}
+      keyboardShouldPersistTaps="handled"
+    >
+      {/* Read-only info */}
+      <View style={[styles.section, { backgroundColor: theme.card, borderColor: theme.border }]}>
+        <Text style={[styles.sectionTitle, { color: theme.text }]}>Account Info</Text>
+        <InfoRow label="Email" value={user?.email ?? '—'} theme={theme} />
+        <InfoRow label="UID" value={user?.uid ?? '—'} theme={theme} mono />
+        <InfoRow label="Ticket Type" value={user?.ticketType ?? '—'} theme={theme} />
+        <InfoRow label="Created" value={user?.createdAt ? new Date(user.createdAt).toLocaleDateString() : '—'} theme={theme} />
+      </View>
+
+      {/* Editable fields */}
+      <View style={[styles.section, { backgroundColor: theme.card, borderColor: theme.border }]}>
+        <Text style={[styles.sectionTitle, { color: theme.text }]}>Edit Profile</Text>
+
+        <Text style={[styles.label, { color: theme.muted }]}>Name</Text>
+        <TextInput
+          style={[styles.input, { backgroundColor: theme.background, color: theme.text, borderColor: theme.border }]}
+          value={name}
+          onChangeText={setName}
+          placeholder="Full name"
+          placeholderTextColor={theme.muted}
+          accessibilityLabel="User name"
+        />
+
+        <Text style={[styles.label, { color: theme.muted }]}>Phone</Text>
+        <TextInput
+          style={[styles.input, { backgroundColor: theme.background, color: theme.text, borderColor: theme.border }]}
+          value={phone}
+          onChangeText={setPhone}
+          placeholder="Phone number"
+          placeholderTextColor={theme.muted}
+          keyboardType="phone-pad"
+          accessibilityLabel="User phone"
+        />
+
+        <Text style={[styles.label, { color: theme.muted }]}>Role</Text>
+        <View style={styles.roleGrid}>
+          {ALL_ROLES.map(r => (
+            <TouchableOpacity
+              key={r}
+              onPress={() => setRole(r)}
+              style={[
+                styles.roleOption,
+                { borderColor: role === r ? theme.primary : theme.border },
+                role === r && { backgroundColor: theme.primary + '22' },
+              ]}
+              accessibilityLabel={`Set role to ${r}`}
+            >
+              <AdminRoleBadge role={r} />
+            </TouchableOpacity>
+          ))}
+        </View>
+
+        <View style={styles.switchRow}>
+          <Text style={[styles.label, { color: theme.muted, marginBottom: 0 }]}>Notifications</Text>
+          <Switch
+            value={notificationsEnabled}
+            onValueChange={setNotificationsEnabled}
+            trackColor={{ false: theme.border, true: theme.primary }}
+            thumbColor="#fff"
+          />
+        </View>
+      </View>
+
+      <TouchableOpacity
+        style={[styles.saveBtn, { backgroundColor: theme.primary }, saving && { opacity: 0.7 }]}
+        onPress={handleSave}
+        disabled={saving}
+        accessibilityLabel="Save user changes"
+      >
+        {saving
+          ? <ActivityIndicator color="#fff" />
+          : <Text style={styles.saveBtnText}>Save Changes</Text>
+        }
+      </TouchableOpacity>
+    </ScrollView>
+  );
+};
+
+const InfoRow = ({
+  label, value, theme, mono,
+}: { label: string; value: string; theme: any; mono?: boolean }) => (
+  <View style={styles.infoRow}>
+    <Text style={[styles.infoLabel, { color: theme.muted }]}>{label}</Text>
+    <Text style={[styles.infoValue, { color: theme.text }, mono && styles.mono]} numberOfLines={1}>
+      {value}
+    </Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  content: { padding: 16, paddingBottom: 40 },
+  center: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  section: { borderRadius: 12, borderWidth: 1, padding: 16, marginBottom: 16 },
+  sectionTitle: { fontSize: 16, fontWeight: '600', marginBottom: 12 },
+  label: { fontSize: 13, marginBottom: 4, marginTop: 12 },
+  input: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 10,
+    fontSize: 15,
+  },
+  roleGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginTop: 4 },
+  roleOption: {
+    borderWidth: 2,
+    borderRadius: 14,
+    padding: 4,
+  },
+  switchRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginTop: 16,
+  },
+  infoRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingVertical: 6,
+  },
+  infoLabel: { fontSize: 13 },
+  infoValue: { fontSize: 13, fontWeight: '500', maxWidth: '60%', textAlign: 'right' },
+  mono: { fontFamily: 'monospace', fontSize: 11 },
+  saveBtn: {
+    padding: 16,
+    borderRadius: 12,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  saveBtnText: { color: '#fff', fontSize: 16, fontWeight: '700' },
+});

--- a/mobile/src/screens/admin/AdminUsersScreen.tsx
+++ b/mobile/src/screens/admin/AdminUsersScreen.tsx
@@ -1,0 +1,174 @@
+import React, { useEffect, useState, useCallback, useRef } from 'react';
+import {
+  View, Text, FlatList, StyleSheet, TouchableOpacity,
+  RefreshControl, ActivityIndicator,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { useTheme } from '../../contexts/ThemeContext';
+import { listAdminUsers, AdminUser } from '../../services/adminService';
+import { AdminSearchBar } from '../../components/admin/AdminSearchBar';
+import { AdminRoleBadge } from '../../components/admin/AdminRoleBadge';
+
+const ROLES = ['all', 'admin', 'staff', 'artist', 'director', 'vendor', 'volunteer', 'attendee'];
+
+export const AdminUsersScreen: React.FC = () => {
+  const { theme } = useTheme();
+  const navigation = useNavigation<any>();
+  const [users, setUsers] = useState<AdminUser[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState('');
+  const [roleFilter, setRoleFilter] = useState('all');
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const fetchUsers = useCallback(async (pageNum = 1, reset = false) => {
+    try {
+      const res = await listAdminUsers({
+        search: search || undefined,
+        role: roleFilter === 'all' ? undefined : roleFilter,
+        page: pageNum,
+        limit: 20,
+      });
+      setUsers(prev => reset ? res.users : [...prev, ...res.users]);
+      setTotal(res.total);
+      setPage(pageNum);
+    } catch (e) {
+      // silently fail on load-more
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+      setLoadingMore(false);
+    }
+  }, [search, roleFilter]);
+
+  useEffect(() => {
+    setLoading(true);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => fetchUsers(1, true), 300);
+    return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
+  }, [fetchUsers]);
+
+  const onRefresh = () => { setRefreshing(true); fetchUsers(1, true); };
+
+  const onEndReached = () => {
+    if (!loadingMore && users.length < total) {
+      setLoadingMore(true);
+      fetchUsers(page + 1);
+    }
+  };
+
+  const renderItem = ({ item }: { item: AdminUser }) => (
+    <TouchableOpacity
+      style={[styles.row, { backgroundColor: theme.card, borderColor: theme.border }]}
+      onPress={() => navigation.navigate('AdminUserDetail', { userId: item.id })}
+      accessibilityLabel={`View user ${item.name}`}
+    >
+      <View style={[styles.avatar, { backgroundColor: theme.primary + '33' }]}>
+        <Text style={[styles.avatarText, { color: theme.primary }]}>
+          {(item.name?.[0] ?? item.email?.[0] ?? '?').toUpperCase()}
+        </Text>
+      </View>
+      <View style={styles.info}>
+        <Text style={[styles.name, { color: theme.text }]} numberOfLines={1}>{item.name || '(no name)'}</Text>
+        <Text style={[styles.email, { color: theme.muted }]} numberOfLines={1}>{item.email}</Text>
+      </View>
+      <AdminRoleBadge role={item.role} small />
+      <Text style={[styles.chevron, { color: theme.muted }]}>›</Text>
+    </TouchableOpacity>
+  );
+
+  return (
+    <View style={[styles.container, { backgroundColor: theme.background }]}>
+      <View style={styles.header}>
+        <AdminSearchBar value={search} onChangeText={setSearch} placeholder="Search by name or email…" />
+        <FlatList
+          horizontal
+          data={ROLES}
+          keyExtractor={r => r}
+          showsHorizontalScrollIndicator={false}
+          style={styles.roleFilters}
+          renderItem={({ item: r }) => (
+            <TouchableOpacity
+              onPress={() => setRoleFilter(r)}
+              style={[
+                styles.chip,
+                { backgroundColor: roleFilter === r ? theme.primary : theme.card, borderColor: theme.border },
+              ]}
+              accessibilityLabel={`Filter by ${r}`}
+            >
+              <Text style={[styles.chipText, { color: roleFilter === r ? '#fff' : theme.text }]}>
+                {r}
+              </Text>
+            </TouchableOpacity>
+          )}
+        />
+        <Text style={[styles.count, { color: theme.muted }]}>{total} users</Text>
+      </View>
+
+      {loading ? (
+        <View style={styles.center}>
+          <ActivityIndicator color={theme.primary} />
+        </View>
+      ) : (
+        <FlatList
+          data={users}
+          keyExtractor={u => u.id}
+          renderItem={renderItem}
+          refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={theme.primary} />}
+          onEndReached={onEndReached}
+          onEndReachedThreshold={0.3}
+          ListEmptyComponent={
+            <View style={styles.center}>
+              <Text style={[styles.empty, { color: theme.muted }]}>No users found</Text>
+            </View>
+          }
+          ListFooterComponent={loadingMore ? <ActivityIndicator color={theme.primary} style={styles.footer} /> : null}
+          contentContainerStyle={styles.list}
+        />
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: { padding: 16, paddingBottom: 0 },
+  roleFilters: { marginBottom: 8 },
+  chip: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+    borderWidth: 1,
+    marginRight: 6,
+  },
+  chipText: { fontSize: 12, fontWeight: '500' },
+  count: { fontSize: 12, marginBottom: 8 },
+  list: { padding: 16, paddingTop: 8 },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 12,
+    borderRadius: 10,
+    borderWidth: 1,
+    marginBottom: 8,
+  },
+  avatar: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: 10,
+  },
+  avatarText: { fontSize: 16, fontWeight: '700' },
+  info: { flex: 1, marginRight: 8 },
+  name: { fontSize: 14, fontWeight: '600', marginBottom: 2 },
+  email: { fontSize: 12 },
+  chevron: { fontSize: 22, marginLeft: 4 },
+  center: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 40 },
+  empty: { fontSize: 14 },
+  footer: { paddingVertical: 16 },
+});

--- a/mobile/src/services/adminService.ts
+++ b/mobile/src/services/adminService.ts
@@ -109,6 +109,12 @@ export const updateAdminUser = async (
 
 // ── Events ─────────────────────────────────────────────────────────────────
 
+export const listAdminEvents = async (): Promise<AdminEvent[]> => {
+  const headers = await authHeaders();
+  const res = await api.get('/events', { headers });
+  return res.data;
+};
+
 export const createAdminEvent = async (
   dto: Omit<AdminEvent, 'id' | 'createdBy'>
 ): Promise<AdminEvent> => {
@@ -162,6 +168,17 @@ export const updateAdminShift = async (
 export const deleteAdminShift = async (id: string): Promise<void> => {
   const headers = await authHeaders();
   await api.delete(`/admin/shifts/${id}`, { headers });
+};
+
+// ── Notifications ─────────────────────────────────────────────────────────
+
+export const sendAdminNotification = async (params: {
+  title: string;
+  body: string;
+  targetGroup?: string;
+}): Promise<void> => {
+  const headers = await authHeaders();
+  await api.post('/notifications/send', params, { headers });
 };
 
 // ── Schedule (admin bypass) ────────────────────────────────────────────────

--- a/mobile/src/services/adminService.ts
+++ b/mobile/src/services/adminService.ts
@@ -1,0 +1,181 @@
+/**
+ * Admin API service — wraps all /admin/* endpoints
+ * All calls require admin role (enforced server-side via RBAC)
+ */
+import { api } from './api';
+import { getIdToken } from './firebaseAuthService';
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface AdminStats {
+  totalUsers: number;
+  totalEvents: number;
+  totalNotifications: number;
+  usersByRole: Record<string, number>;
+}
+
+export interface AdminUser {
+  id: string;
+  uid: string;
+  name: string;
+  email: string;
+  phone?: string;
+  role: string;
+  ticketType?: string;
+  notificationsEnabled?: boolean;
+  profilePictureUrl?: string;
+  createdAt?: string;
+  userGroups?: string[];
+}
+
+export interface AdminUserListResponse {
+  users: AdminUser[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+export interface AdminShift {
+  id: string;
+  userId: string;
+  userName: string;
+  role: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  location: string;
+  stage?: string;
+  notes?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface AdminEvent {
+  id: string;
+  name: string;
+  stage: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  description?: string;
+  imageUrl?: string;
+  genres?: string[];
+  artists?: string[];
+  createdBy?: string;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+const authHeaders = async () => {
+  const token = await getIdToken();
+  return { Authorization: `Bearer ${token}` };
+};
+
+// ── Stats ──────────────────────────────────────────────────────────────────
+
+export const getAdminStats = async (): Promise<AdminStats> => {
+  const headers = await authHeaders();
+  const res = await api.get('/admin/stats', { headers });
+  return res.data;
+};
+
+// ── Users ──────────────────────────────────────────────────────────────────
+
+export const listAdminUsers = async (params?: {
+  search?: string;
+  role?: string;
+  page?: number;
+  limit?: number;
+}): Promise<AdminUserListResponse> => {
+  const headers = await authHeaders();
+  const res = await api.get('/admin/users', { headers, params });
+  return res.data;
+};
+
+export const getAdminUser = async (id: string): Promise<AdminUser> => {
+  const headers = await authHeaders();
+  const res = await api.get(`/admin/users/${id}`, { headers });
+  return res.data;
+};
+
+export const updateAdminUser = async (
+  id: string,
+  dto: Partial<Pick<AdminUser, 'name' | 'phone' | 'role' | 'notificationsEnabled' | 'ticketType' | 'userGroups'>>
+): Promise<AdminUser> => {
+  const headers = await authHeaders();
+  const res = await api.patch(`/admin/users/${id}`, dto, { headers });
+  return res.data;
+};
+
+// ── Events ─────────────────────────────────────────────────────────────────
+
+export const createAdminEvent = async (
+  dto: Omit<AdminEvent, 'id' | 'createdBy'>
+): Promise<AdminEvent> => {
+  const headers = await authHeaders();
+  const res = await api.post('/admin/events', dto, { headers });
+  return res.data;
+};
+
+export const updateAdminEvent = async (
+  id: string,
+  dto: Partial<Omit<AdminEvent, 'id' | 'createdBy'>>
+): Promise<AdminEvent> => {
+  const headers = await authHeaders();
+  const res = await api.patch(`/admin/events/${id}`, dto, { headers });
+  return res.data;
+};
+
+export const deleteAdminEvent = async (id: string): Promise<void> => {
+  const headers = await authHeaders();
+  await api.delete(`/admin/events/${id}`, { headers });
+};
+
+// ── Shifts ─────────────────────────────────────────────────────────────────
+
+export const listAdminShifts = async (params?: {
+  date?: string;
+  role?: string;
+}): Promise<AdminShift[]> => {
+  const headers = await authHeaders();
+  const res = await api.get('/admin/shifts', { headers, params });
+  return res.data;
+};
+
+export const createAdminShift = async (
+  dto: Omit<AdminShift, 'id' | 'createdAt' | 'updatedAt'>
+): Promise<AdminShift> => {
+  const headers = await authHeaders();
+  const res = await api.post('/admin/shifts', dto, { headers });
+  return res.data;
+};
+
+export const updateAdminShift = async (
+  id: string,
+  dto: Partial<Omit<AdminShift, 'id' | 'createdAt' | 'updatedAt'>>
+): Promise<AdminShift> => {
+  const headers = await authHeaders();
+  const res = await api.patch(`/admin/shifts/${id}`, dto, { headers });
+  return res.data;
+};
+
+export const deleteAdminShift = async (id: string): Promise<void> => {
+  const headers = await authHeaders();
+  await api.delete(`/admin/shifts/${id}`, { headers });
+};
+
+// ── Schedule (admin bypass) ────────────────────────────────────────────────
+
+export const getAdminUserSchedule = async (userId: string): Promise<{ eventIds: string[] }> => {
+  const headers = await authHeaders();
+  const res = await api.get(`/admin/schedule/${userId}`, { headers });
+  return res.data;
+};
+
+export const setAdminUserSchedule = async (
+  userId: string,
+  eventIds: string[]
+): Promise<void> => {
+  const headers = await authHeaders();
+  await api.put(`/admin/schedule/${userId}`, { eventIds }, { headers });
+};


### PR DESCRIPTION
## BFF-S3-06: Admin Control Panel (Frontend)

Full admin panel UI. RBAC-gated to `role === 'admin'`. All 7 screens implement the 15 endpoints from Samantha's PR #16.

## New files (14 changed, 1840 insertions)

### `adminService.ts`
All 15 admin endpoints typed: stats, user list/detail/update, event create/update/delete, shift list/create/update/delete, schedule get/set/add/remove.

### Shared components
- **AdminRoleBadge** — color-coded pill per role (admin=red, staff=orange, artist=purple, etc.)
- **AdminStatCard** — stat tile (icon + large number + label)  
- **AdminSearchBar** — debounced controlled text input

### Screens
| Screen | Route | Description |
|--------|-------|-------------|
| AdminDashboardScreen | `AdminPanel` | Stats cards, users-by-role, quick action nav buttons |
| AdminUsersScreen | `AdminUsers` | Paginated list, search, role filter chips, infinite scroll |
| AdminUserDetailScreen | `AdminUserDetail` | Read-only account info + editable name/phone/role/notifications |
| AdminEventsScreen | `AdminEvents` | Event list with search, swipe delete, + New button |
| AdminEventEditScreen | `AdminEventEdit` | Create/edit form for all event fields |
| AdminShiftsScreen | `AdminShifts` | Shifts grouped by date, date/role filter, create modal |
| AdminScheduleScreen | `AdminSchedule` | Full schedule with stage color coding, tap-to-edit |
| AdminNotificationsScreen | `AdminNotifications` | Send to user group with confirmation + last-sent banner |

### Navigation (`navigation/index.tsx`)
- `RootStackParamList` extended with all 7 admin routes
- All screens registered in the root stack

### Settings entry point
- Settings admin section now has **Admin Control Panel** button (navigates to AdminDashboard) in addition to existing Send Notification button

## RBAC
- `AdminDashboardScreen` renders an access-denied view for non-admin users
- Navigation routes only appear when user has `role === 'admin'` in Settings admin section

## TypeScript
Clean — `tsc --noEmit` passes

## Dependencies
Requires PR #16 (Samantha's backend) to be merged before end-to-end testing.