### PR TITLE
feat(load-test): BFF-S3-07 — k6 load testing framework for 4,000 concurrent users

### DIFF
--- a/backend/load-tests/README.md
+++ b/backend/load-tests/README.md
@@ -1,0 +1,109 @@
+# BFF-S3-07: Load Testing Framework
+
+Load testing suite for the Big Fam Festival API using [k6](https://k6.io/).
+Target: **4,000 concurrent users** against the dev environment.
+
+## Prerequisites
+
+```bash
+# Install k6
+brew install k6
+
+# Verify
+k6 version
+```
+
+## Test Scenarios
+
+| Script | Purpose | Peak VUs | Duration |
+|---|---|---|---|
+| `attendee-flow.js` | Typical attendee journey (events → artists → schedule) | 4,000 | 16 min |
+| `spike-test.js` | Sudden traffic spike (headliner announcement) | 4,000 | ~4 min |
+| `stress-test.js` | Find breaking point (ramps to 10,000 VUs) | 10,000 | ~19 min |
+
+## Usage
+
+### Smoke Test (quick validation — 10 VUs)
+```bash
+cd backend
+k6 run --env BASE_URL=http://localhost:8080/api/v1 --env PROFILE=smoke load-tests/attendee-flow.js
+```
+
+### Full Load Test (4,000 VUs)
+```bash
+# Against local dev
+k6 run --env BASE_URL=http://localhost:8080/api/v1 load-tests/attendee-flow.js
+
+# Against deployed dev environment
+k6 run --env BASE_URL=https://bigfam-api-dev-xxxxx.run.app/api/v1 load-tests/attendee-flow.js
+```
+
+### Spike Test
+```bash
+k6 run --env BASE_URL=http://localhost:8080/api/v1 load-tests/spike-test.js
+```
+
+### Stress Test (find the ceiling)
+```bash
+k6 run --env BASE_URL=http://localhost:8080/api/v1 load-tests/stress-test.js
+```
+
+### With Authentication (for profile/schedule endpoints)
+```bash
+# Generate a test token first
+node load-tests/generate-test-token.js > /tmp/k6-token.txt
+
+# Run with token
+k6 run \
+  --env BASE_URL=http://localhost:8080/api/v1 \
+  --env AUTH_TOKEN=$(cat /tmp/k6-token.txt) \
+  load-tests/attendee-flow.js
+```
+
+### Export Results (JSON)
+```bash
+k6 run --out json=results/attendee-flow.json load-tests/attendee-flow.js
+```
+
+## Thresholds
+
+Default pass/fail criteria:
+
+| Metric | Threshold | Notes |
+|---|---|---|
+| `http_req_duration` p95 | < 500ms | Median user experience |
+| `http_req_duration` p99 | < 1000ms | Tail latency |
+| `http_req_failed` | < 1% | Error rate |
+| `http_reqs` rate | > 100 rps | Minimum throughput |
+| `event_list_duration` p95 | < 300ms | Events are the hottest endpoint |
+| `artist_list_duration` p95 | < 300ms | Artists browsing |
+
+Spike test uses relaxed thresholds (p95 < 2s, 5% error rate OK).
+Stress test uses very relaxed thresholds — the goal is to find where things break.
+
+## Results Directory
+
+Test results are saved to `backend/load-tests/results/`. This directory is gitignored.
+
+## Interpreting Results
+
+After a run, k6 outputs a summary table. Key columns:
+
+- **http_req_duration**: Response time distribution (avg, p90, p95, p99, max)
+- **http_req_failed**: Percentage of failed requests
+- **http_reqs**: Total request count and rate
+- **vus**: Number of virtual users active
+- **iteration_duration**: Full iteration time (one user's complete flow)
+
+### What to look for:
+1. **p95 over 500ms** → Firestore query optimization needed
+2. **Error rate > 1%** → Check rate limiter config or Firestore connection limits
+3. **Throughput plateau** → Backend is CPU or connection-bound
+4. **Spike test failures** → Cloud Run autoscaling too slow (adjust min instances)
+
+## Architecture Notes
+
+- **Cloud Run autoscaling**: min instances = 0 by default (cold starts in spike test). For production, set min instances = 2+
+- **Firestore**: Reads scale automatically but writes have per-document limits (1 write/sec/doc)
+- **Rate limiter**: Default 100 req/60s per IP — k6 runs from a single IP so tests will trigger throttling. Temporarily increase or whitelist for load tests.
+- **CORS**: Not relevant for k6 (no browser)

--- a/backend/load-tests/attendee-flow.js
+++ b/backend/load-tests/attendee-flow.js
@@ -1,0 +1,132 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Rate, Trend } from 'k6/metrics';
+import {
+  BASE_URL,
+  THRESHOLDS,
+  FULL_LOAD_STAGES,
+  SMOKE_STAGES,
+  authHeaders,
+  publicHeaders,
+} from './config.js';
+
+/**
+ * BFF-S3-07: Attendee Flow Load Test
+ *
+ * Simulates the typical festival attendee journey:
+ *   1. Health check (app cold start)
+ *   2. Browse events (public — heaviest traffic)
+ *   3. Browse artists (public)
+ *   4. Get stages list (public)
+ *   5. View single event (public)
+ *   6. Get own profile (authenticated)
+ *   7. Get own schedule (authenticated)
+ *
+ * Run:
+ *   k6 run --env BASE_URL=https://your-dev-url/api/v1 load-tests/attendee-flow.js
+ *   k6 run --env BASE_URL=http://localhost:8080/api/v1 --env PROFILE=smoke load-tests/attendee-flow.js
+ */
+
+// Custom metrics
+const eventListDuration = new Trend('event_list_duration', true);
+const artistListDuration = new Trend('artist_list_duration', true);
+const profileDuration = new Trend('profile_duration', true);
+const scheduleDuration = new Trend('schedule_duration', true);
+const errorRate = new Rate('errors');
+
+// Select profile from env
+const profile = __ENV.PROFILE || 'full';
+const stages = profile === 'smoke' ? SMOKE_STAGES : FULL_LOAD_STAGES;
+
+export const options = {
+  stages,
+  thresholds: {
+    ...THRESHOLDS,
+    'event_list_duration': ['p(95)<300'],
+    'artist_list_duration': ['p(95)<300'],
+    'profile_duration': ['p(95)<500'],
+    'schedule_duration': ['p(95)<500'],
+  },
+};
+
+export default function () {
+  // 1. Health check — simulates app cold start connectivity check
+  {
+    const res = http.get(`${BASE_URL}/health/ready`, { headers: publicHeaders() });
+    check(res, { 'health: status 200': (r) => r.status === 200 }) || errorRate.add(1);
+  }
+
+  sleep(0.5 + Math.random());
+
+  // 2. Browse events — the #1 traffic endpoint at a festival
+  {
+    const res = http.get(`${BASE_URL}/events`, { headers: publicHeaders() });
+    check(res, {
+      'events: status 200': (r) => r.status === 200,
+      'events: returns array': (r) => {
+        try { return Array.isArray(JSON.parse(r.body)); } catch { return false; }
+      },
+    }) || errorRate.add(1);
+    eventListDuration.add(res.timings.duration);
+  }
+
+  sleep(0.5 + Math.random());
+
+  // 3. Browse artists
+  {
+    const res = http.get(`${BASE_URL}/artists`, { headers: publicHeaders() });
+    check(res, { 'artists: status 200': (r) => r.status === 200 }) || errorRate.add(1);
+    artistListDuration.add(res.timings.duration);
+  }
+
+  sleep(0.3 + Math.random() * 0.5);
+
+  // 4. Get stages
+  {
+    const res = http.get(`${BASE_URL}/events/stages`, { headers: publicHeaders() });
+    check(res, { 'stages: status 200': (r) => r.status === 200 }) || errorRate.add(1);
+  }
+
+  sleep(0.3 + Math.random() * 0.5);
+
+  // 5. View a single event (simulate tapping on one)
+  {
+    // First get the list, then pick a random event
+    const listRes = http.get(`${BASE_URL}/events`, { headers: publicHeaders() });
+    try {
+      const events = JSON.parse(listRes.body);
+      if (events.length > 0) {
+        const event = events[Math.floor(Math.random() * events.length)];
+        const res = http.get(`${BASE_URL}/events/${event.id}`, { headers: publicHeaders() });
+        check(res, { 'event detail: status 200': (r) => r.status === 200 }) || errorRate.add(1);
+      }
+    } catch {
+      errorRate.add(1);
+    }
+  }
+
+  sleep(0.5 + Math.random());
+
+  // 6-7: Authenticated endpoints — only if token is provided
+  const headers = authHeaders();
+  if (headers.Authorization) {
+    // 6. Get own profile
+    {
+      const res = http.get(`${BASE_URL}/users/profile`, { headers });
+      check(res, { 'profile: status 200': (r) => r.status === 200 }) || errorRate.add(1);
+      profileDuration.add(res.timings.duration);
+    }
+
+    sleep(0.3 + Math.random() * 0.5);
+
+    // 7. Get own schedule
+    {
+      const res = http.get(`${BASE_URL}/schedule`, { headers });
+      check(res, { 'schedule: status 200': (r) => r.status === 200 }) || errorRate.add(1);
+      scheduleDuration.add(res.timings.duration);
+    }
+  }
+
+  // Think time — simulate user reading content between page transitions
+  sleep(1 + Math.random() * 3);
+}

--- a/backend/load-tests/attendee-flow.js
+++ b/backend/load-tests/attendee-flow.js
@@ -59,6 +59,7 @@ export default function () {
   sleep(0.5 + Math.random());
 
   // 2. Browse events — the #1 traffic endpoint at a festival
+  let eventIds = [];
   {
     const res = http.get(`${BASE_URL}/events`, { headers: publicHeaders() });
     check(res, {
@@ -68,6 +69,7 @@ export default function () {
       },
     }) || errorRate.add(1);
     eventListDuration.add(res.timings.duration);
+    try { eventIds = JSON.parse(res.body).map(e => e.id); } catch {}
   }
 
   sleep(0.5 + Math.random());
@@ -89,20 +91,11 @@ export default function () {
 
   sleep(0.3 + Math.random() * 0.5);
 
-  // 5. View a single event (simulate tapping on one)
-  {
-    // First get the list, then pick a random event
-    const listRes = http.get(`${BASE_URL}/events`, { headers: publicHeaders() });
-    try {
-      const events = JSON.parse(listRes.body);
-      if (events.length > 0) {
-        const event = events[Math.floor(Math.random() * events.length)];
-        const res = http.get(`${BASE_URL}/events/${event.id}`, { headers: publicHeaders() });
-        check(res, { 'event detail: status 200': (r) => r.status === 200 }) || errorRate.add(1);
-      }
-    } catch {
-      errorRate.add(1);
-    }
+  // 5. View a single event (simulate tapping on one — reuse IDs from step 2)
+  if (eventIds.length > 0) {
+    const id = eventIds[Math.floor(Math.random() * eventIds.length)];
+    const res = http.get(`${BASE_URL}/events/${id}`, { headers: publicHeaders() });
+    check(res, { 'event detail: status 200': (r) => r.status === 200 }) || errorRate.add(1);
   }
 
   sleep(0.5 + Math.random());

--- a/backend/load-tests/config.js
+++ b/backend/load-tests/config.js
@@ -1,0 +1,85 @@
+/**
+ * BFF-S3-07: Load Testing — k6 Configuration
+ *
+ * Shared config and helpers for all load test scenarios.
+ * See README.md in this directory for setup and usage.
+ */
+
+// Default target — override with K6_BASE_URL env var
+export const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080/api/v1';
+
+// Firebase Auth token for authenticated requests.
+// Generate a test token before running:
+//   node scripts/generate-test-token.js > /tmp/k6-token.txt
+// Then run k6 with: k6 run -e AUTH_TOKEN=$(cat /tmp/k6-token.txt) ...
+export const AUTH_TOKEN = __ENV.AUTH_TOKEN || '';
+
+/**
+ * Standard thresholds for the Big Fam API.
+ * Target: handle 4,000 concurrent users.
+ */
+export const THRESHOLDS = {
+  // 95th percentile response time under 500ms
+  'http_req_duration': ['p(95)<500', 'p(99)<1000'],
+  // Less than 1% error rate
+  'http_req_failed': ['rate<0.01'],
+  // At least 100 requests per second throughput
+  'http_reqs': ['rate>100'],
+};
+
+/**
+ * Ramp-up profile targeting 4,000 concurrent VUs.
+ * Stages:
+ *   1. Warm-up:  0 → 100 VUs over 1 min
+ *   2. Ramp:   100 → 1000 VUs over 3 min
+ *   3. Load:  1000 → 4000 VUs over 5 min
+ *   4. Sustain: 4000 VUs for 5 min (steady state)
+ *   5. Cool:  4000 → 0 VUs over 2 min
+ */
+export const FULL_LOAD_STAGES = [
+  { duration: '1m',  target: 100 },
+  { duration: '3m',  target: 1000 },
+  { duration: '5m',  target: 4000 },
+  { duration: '5m',  target: 4000 },
+  { duration: '2m',  target: 0 },
+];
+
+/**
+ * Smoke test profile — quick validation with low load.
+ */
+export const SMOKE_STAGES = [
+  { duration: '30s', target: 10 },
+  { duration: '1m',  target: 10 },
+  { duration: '30s', target: 0 },
+];
+
+/**
+ * Soak test profile — moderate load over extended period.
+ */
+export const SOAK_STAGES = [
+  { duration: '2m',  target: 500 },
+  { duration: '30m', target: 500 },
+  { duration: '2m',  target: 0 },
+];
+
+/**
+ * Build standard headers for authenticated requests.
+ */
+export function authHeaders() {
+  const headers = {
+    'Content-Type': 'application/json',
+  };
+  if (AUTH_TOKEN) {
+    headers['Authorization'] = `Bearer ${AUTH_TOKEN}`;
+  }
+  return headers;
+}
+
+/**
+ * Build headers for public endpoints (no auth).
+ */
+export function publicHeaders() {
+  return {
+    'Content-Type': 'application/json',
+  };
+}

--- a/backend/load-tests/generate-test-token.js
+++ b/backend/load-tests/generate-test-token.js
@@ -1,0 +1,79 @@
+/**
+ * Generate a Firebase custom token for load testing authenticated endpoints.
+ *
+ * Usage:
+ *   node load-tests/generate-test-token.js
+ *   node load-tests/generate-test-token.js > /tmp/k6-token.txt
+ *
+ * Then run k6 with:
+ *   k6 run -e AUTH_TOKEN=$(cat /tmp/k6-token.txt) -e BASE_URL=http://localhost:8080/api/v1 load-tests/attendee-flow.js
+ *
+ * Requires GOOGLE_APPLICATION_CREDENTIALS env var or bigfam-dev-serviceaccount.json in backend/.
+ */
+
+const admin = require('firebase-admin');
+const path = require('path');
+const fs = require('fs');
+const dotenv = require('dotenv');
+
+dotenv.config({ path: path.join(__dirname, '..', '.env') });
+
+const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS || 
+  path.join(__dirname, '..', 'bigfam-dev-serviceaccount.json');
+
+if (!admin.apps.length) {
+  if (fs.existsSync(credPath)) {
+    const sa = JSON.parse(fs.readFileSync(credPath, 'utf8'));
+    admin.initializeApp({ credential: admin.credential.cert(sa) });
+  } else {
+    console.error(`Service account key not found at: ${credPath}`);
+    console.error('Set GOOGLE_APPLICATION_CREDENTIALS or place bigfam-dev-serviceaccount.json in backend/');
+    process.exit(1);
+  }
+}
+
+const LOAD_TEST_UID = 'load-test-user-0001';
+
+async function main() {
+  try {
+    // Create a custom token with ATTENDEE role
+    const customToken = await admin.auth().createCustomToken(LOAD_TEST_UID, {
+      role: 'ATTENDEE',
+    });
+
+    // Exchange custom token for an ID token via Firebase REST API
+    const projectId = admin.app().options.projectId || 
+      JSON.parse(fs.readFileSync(credPath, 'utf8')).project_id;
+
+    const fetch = globalThis.fetch || (await import('node-fetch')).default;
+    const res = await fetch(
+      `https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=AIzaSyDummy`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          token: customToken,
+          returnSecureToken: true,
+        }),
+      }
+    );
+
+    if (!res.ok) {
+      // Custom tokens can't be used directly with k6 — output the custom token
+      // and note that the test user needs to exist in Firebase Auth
+      console.error('Note: Custom token generated but ID token exchange requires a valid API key.');
+      console.error('For load testing, consider using a real user ID token from Firebase.');
+      console.error('Custom token (use with Firebase client SDK to get ID token):');
+      process.stdout.write(customToken);
+      process.exit(0);
+    }
+
+    const data = await res.json();
+    process.stdout.write(data.idToken);
+  } catch (err) {
+    console.error('Error generating token:', err.message);
+    process.exit(1);
+  }
+}
+
+main();

--- a/backend/load-tests/generate-test-token.js
+++ b/backend/load-tests/generate-test-token.js
@@ -42,12 +42,17 @@ async function main() {
     });
 
     // Exchange custom token for an ID token via Firebase REST API
-    const projectId = admin.app().options.projectId || 
-      JSON.parse(fs.readFileSync(credPath, 'utf8')).project_id;
+    const apiKey = process.env.FIREBASE_WEB_API_KEY;
+    if (!apiKey) {
+      console.error('FIREBASE_WEB_API_KEY not set (find it in Firebase Console → Project Settings → Web API Key).');
+      console.error('Outputting custom token instead. Use this with a Firebase client SDK to get an ID token.');
+      process.stdout.write(customToken);
+      process.exit(0);
+    }
 
     const fetch = globalThis.fetch || (await import('node-fetch')).default;
     const res = await fetch(
-      `https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=AIzaSyDummy`,
+      `https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=${apiKey}`,
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -59,11 +64,9 @@ async function main() {
     );
 
     if (!res.ok) {
-      // Custom tokens can't be used directly with k6 — output the custom token
-      // and note that the test user needs to exist in Firebase Auth
-      console.error('Note: Custom token generated but ID token exchange requires a valid API key.');
-      console.error('For load testing, consider using a real user ID token from Firebase.');
-      console.error('Custom token (use with Firebase client SDK to get ID token):');
+      const errBody = await res.text();
+      console.error(`ID token exchange failed (HTTP ${res.status}): ${errBody}`);
+      console.error('Falling back to custom token output.');
       process.stdout.write(customToken);
       process.exit(0);
     }

--- a/backend/load-tests/results/.gitignore
+++ b/backend/load-tests/results/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/backend/load-tests/spike-test.js
+++ b/backend/load-tests/spike-test.js
@@ -1,0 +1,57 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Rate, Trend } from 'k6/metrics';
+import {
+  BASE_URL,
+  THRESHOLDS,
+  SMOKE_STAGES,
+  publicHeaders,
+} from './config.js';
+
+/**
+ * BFF-S3-07: Spike Test
+ *
+ * Simulates a sudden spike in traffic — e.g., headliner announcement
+ * or festival gates opening. Tests system behavior under sudden load.
+ *
+ * Profile: 0 → 4000 VUs in 30 seconds, hold for 2 minutes, then drop.
+ *
+ * Run:
+ *   k6 run --env BASE_URL=https://your-dev-url/api/v1 load-tests/spike-test.js
+ */
+
+const errorRate = new Rate('errors');
+const eventsDuration = new Trend('events_duration', true);
+
+export const options = {
+  stages: [
+    { duration: '10s', target: 100 },    // Quick warm-up
+    { duration: '30s', target: 4000 },   // SPIKE — 0 to 4000 in 30s
+    { duration: '2m',  target: 4000 },   // Hold at peak
+    { duration: '30s', target: 100 },    // Rapid cooldown
+    { duration: '30s', target: 0 },      // Drain
+  ],
+  thresholds: {
+    ...THRESHOLDS,
+    // Spike test is more lenient on latency — we care about not crashing
+    'http_req_duration': ['p(95)<2000', 'p(99)<5000'],
+    'http_req_failed': ['rate<0.05'],  // Up to 5% error rate acceptable during spike
+  },
+};
+
+export default function () {
+  // Hammer the two hottest endpoints — events and health
+  const batch = http.batch([
+    ['GET', `${BASE_URL}/events`, null, { headers: publicHeaders() }],
+    ['GET', `${BASE_URL}/health/ready`, null, { headers: publicHeaders() }],
+    ['GET', `${BASE_URL}/artists`, null, { headers: publicHeaders() }],
+  ]);
+
+  check(batch[0], { 'events: 200': (r) => r.status === 200 }) || errorRate.add(1);
+  check(batch[1], { 'health: 200': (r) => r.status === 200 }) || errorRate.add(1);
+  check(batch[2], { 'artists: 200': (r) => r.status === 200 }) || errorRate.add(1);
+
+  eventsDuration.add(batch[0].timings.duration);
+
+  sleep(0.1 + Math.random() * 0.5);
+}

--- a/backend/load-tests/stress-test.js
+++ b/backend/load-tests/stress-test.js
@@ -1,0 +1,51 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Rate, Trend } from 'k6/metrics';
+import {
+  BASE_URL,
+  THRESHOLDS,
+  authHeaders,
+  publicHeaders,
+} from './config.js';
+
+/**
+ * BFF-S3-07: Stress Test — Find Breaking Point
+ *
+ * Ramps well past 4,000 VUs to find where the system degrades or breaks.
+ * Used to identify the hard ceiling for capacity planning.
+ *
+ * Run:
+ *   k6 run --env BASE_URL=https://your-dev-url/api/v1 load-tests/stress-test.js
+ */
+
+const errorRate = new Rate('errors');
+
+export const options = {
+  stages: [
+    { duration: '2m',  target: 1000 },
+    { duration: '3m',  target: 2000 },
+    { duration: '3m',  target: 4000 },
+    { duration: '3m',  target: 6000 },   // Past target — looking for degradation
+    { duration: '3m',  target: 8000 },   // Way past target — find the ceiling
+    { duration: '2m',  target: 10000 },  // Absolute max — expect failures here
+    { duration: '3m',  target: 0 },      // Recovery
+  ],
+  thresholds: {
+    // Relaxed — we WANT to find the break point
+    'http_req_duration': ['p(95)<3000'],
+    'http_req_failed': ['rate<0.10'],
+  },
+};
+
+export default function () {
+  // Mix of public and potentially-authenticated requests
+  const res = http.get(`${BASE_URL}/events`, { headers: publicHeaders() });
+  check(res, { 'events: not 5xx': (r) => r.status < 500 }) || errorRate.add(1);
+
+  sleep(0.5 + Math.random());
+
+  const healthRes = http.get(`${BASE_URL}/health/ready`, { headers: publicHeaders() });
+  check(healthRes, { 'health: not 5xx': (r) => r.status < 500 }) || errorRate.add(1);
+
+  sleep(0.2 + Math.random() * 0.5);
+}

--- a/docs/audits/BFF-S3-07-load-testing.md
+++ b/docs/audits/BFF-S3-07-load-testing.md
@@ -1,0 +1,52 @@
+# BFF-S3-07: Load Testing Setup
+
+**Date:** 2026-04-14  
+**Author:** Koda  
+**Branch:** BFF-S3-07-load-testing → dev
+
+---
+
+## Summary
+
+k6 load testing framework targeting 4,000 concurrent users against the Big Fam API. Three test scenarios covering normal usage, spike traffic, and stress/breaking point analysis.
+
+---
+
+## Files Added
+
+| File | Purpose |
+|---|---|
+| `load-tests/config.js` | Shared config: BASE_URL, thresholds, ramp profiles, auth helpers |
+| `load-tests/attendee-flow.js` | Full attendee journey (health → events → artists → schedule) at 4,000 VUs |
+| `load-tests/spike-test.js` | Sudden spike: 0 → 4,000 VUs in 30s, hold 2 min |
+| `load-tests/stress-test.js` | Breaking point finder: ramps to 10,000 VUs |
+| `load-tests/generate-test-token.js` | Firebase test token generator for authenticated endpoints |
+| `load-tests/README.md` | Usage docs, thresholds, architecture notes |
+| `load-tests/results/.gitignore` | Results dir (gitignored — output only) |
+
+---
+
+## Thresholds
+
+| Metric | Target | Notes |
+|---|---|---|
+| p95 response time | < 500ms | Normal load |
+| p99 response time | < 1000ms | Tail latency |
+| Error rate | < 1% | Acceptable failure rate |
+| Throughput | > 100 rps | Minimum sustained rate |
+| Events endpoint p95 | < 300ms | Hottest public endpoint |
+
+---
+
+## Known Considerations
+
+1. **Rate limiter**: Default 100 req/60s per IP will trigger on single-source k6 runs. Must temporarily increase or whitelist load test IP.
+2. **Cloud Run cold starts**: Min instances = 0 causes cold start penalties in spike test. Production should set min instances ≥ 2.
+3. **Firestore per-document write limit**: 1 write/sec/doc. Schedule and profile writes may bottleneck under high write concurrency.
+4. **Firebase Auth token**: Authenticated tests require a valid token. generate-test-token.js provides a starting point but may need a real user token for full auth flow.
+
+---
+
+## Validation
+
+Smoke test executed locally confirming k6 scripts compile and execute correctly. All metrics report, thresholds evaluate, and custom metrics track per-endpoint latency.


### PR DESCRIPTION
## BFF-S3-07: Load Testing Framework

### What's in it
k6 load testing suite targeting 4,000 concurrent users against the Big Fam API.

**Three scenarios:**
| Script | Purpose | Peak VUs | Duration |
|---|---|---|---|
| `attendee-flow.js` | Full attendee journey (events→artists→schedule) | 4,000 | 16 min |
| `spike-test.js` | Sudden spike (headliner announcement sim) | 4,000 | ~4 min |
| `stress-test.js` | Find breaking point (ramps to 10,000 VUs) | 10,000 | ~19 min |

**Supporting files:**
- `config.js` — shared thresholds, ramp profiles, auth helpers
- `generate-test-token.js` — Firebase custom token for authenticated endpoints
- `README.md` — full usage docs, threshold explanations, architecture notes
- `results/` — gitignored output directory

### Thresholds
- p95 < 500ms, p99 < 1s, < 1% error rate, > 100 rps
- Events/artists endpoints: p95 < 300ms

### Known items (documented in audit doc)
1. Rate limiter (100/60s per IP) will trigger — must whitelist for load tests
2. Cloud Run min instances should be ≥ 2 in prod (cold start penalty)
3. Firestore per-document write limit (1/sec) may bottleneck schedule writes

### Validation
Smoke test executed locally — k6 v1.7.1 confirms scripts compile, execute, and report all metrics correctly.

### Audit doc
`docs/audits/BFF-S3-07-load-testing.md`