### PR TITLE
fix(mobile): add promise polyfill for Android bundling

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -41,6 +41,7 @@
         "expo-status-bar": "~3.0.8",
         "firebase": "^12.3.0",
         "lottie-react-native": "~7.3.1",
+        "promise": "^8.3.0",
         "react": "19.1.0",
         "react-native": "0.81.4",
         "react-native-gesture-handler": "~2.28.0",
@@ -16101,6 +16102,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/promise": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
+      "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "asap": "~2.0.6"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -16634,15 +16644,6 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.29.1"
-      }
-    },
-    "node_modules/react-native/node_modules/promise": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
-      "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
-      "license": "MIT",
-      "dependencies": {
-        "asap": "~2.0.6"
       }
     },
     "node_modules/react-native/node_modules/semver": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -47,6 +47,7 @@
     "expo-status-bar": "~3.0.8",
     "firebase": "^12.3.0",
     "lottie-react-native": "~7.3.1",
+    "promise": "^8.3.0",
     "react": "19.1.0",
     "react-native": "0.81.4",
     "react-native-gesture-handler": "~2.28.0",


### PR DESCRIPTION
Fixes `Unable to resolve module promise/setimmediate/done` blocking Android beta builds.

**Root cause:** `promise` package nested inside `react-native/node_modules/` — Metro can't resolve it from `@sentry/react-native`'s context.

**Fix:** Added `promise@^8.3.0` as direct dependency to hoist to top-level `node_modules/`.

**Verified:** `npx expo export:embed --eager --platform android --dev false` ✅

Sprint 3 gating — unblocks S3-05 beta execution.