### PR TITLE
fix(cicd): use explicit build ID for eas submit in non-interactive mode

### DIFF
--- a/.github/workflows/android-deploy.yml
+++ b/.github/workflows/android-deploy.yml
@@ -61,8 +61,18 @@ jobs:
           echo "${{ secrets.GOOGLE_PLAY_SA_KEY }}" | base64 --decode > mobile/google-play-service-account.json
         shell: bash
 
+      - name: Get latest Android build ID
+        id: get-build
+        run: |
+          BUILD_ID=$(eas build:list --platform android --status finished --limit 1 --non-interactive --json | python3 -c "import sys,json; print(json.load(sys.stdin)[0]['id'])")
+          echo "build_id=$BUILD_ID" >> "$GITHUB_OUTPUT"
+          echo "Latest build ID: $BUILD_ID"
+        working-directory: mobile
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+
       - name: Submit to Google Play — internal track
-        run: eas submit --platform android --profile beta --latest --non-interactive
+        run: eas submit --platform android --profile beta --id ${{ steps.get-build.outputs.build_id }} --non-interactive
         working-directory: mobile
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}


### PR DESCRIPTION
## Sprint 3 Unblocker — S3-05 Beta Deployment

**Error:** `You need to specify the archive source when running in non-interactive mode`

**Root cause:** `eas submit --latest --non-interactive` doesn't accept `--latest` as a valid archive source in non-interactive mode.

**Fix:** Added a step to fetch the latest finished Android build ID via `eas build:list`, then passes it explicitly with `--id` to `eas submit`.

**Before:**
```
eas submit --platform android --profile beta --latest --non-interactive
```

**After:**
```
# Step 1: Get build ID
eas build:list --platform android --status finished --limit 1 --non-interactive --json

# Step 2: Submit with explicit ID
eas submit --platform android --profile beta --id $BUILD_ID --non-interactive
```

No other changes. Workflow trigger and cleanup steps unchanged.