### PR TITLE
fix(cicd): correct Play track name and add --latest to eas submit

### DIFF
--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Submit Android to Google Play (${{ steps.profile.outputs.profile }})
         if: steps.profile.outputs.profile == 'beta' || steps.profile.outputs.profile == 'production'
-        run: eas submit --platform android --profile ${{ steps.profile.outputs.profile }} --non-interactive
+        run: eas submit --platform android --profile ${{ steps.profile.outputs.profile }} --latest --non-interactive
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           GOOGLE_PLAY_SA_KEY: ${{ secrets.GOOGLE_PLAY_SA_KEY }}

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -81,7 +81,7 @@
     "beta": {
       "android": {
         "serviceAccountKeyPath": "./google-play-service-account.json",
-        "track": "CLOSED-BETA"
+        "track": "alpha"
       }
     }
   }

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -81,7 +81,7 @@
     "beta": {
       "android": {
         "serviceAccountKeyPath": "./google-play-service-account.json",
-        "track": "internal"
+        "track": "CLOSED-BETA"
       }
     }
   }


### PR DESCRIPTION
## Two CI/CD fixes for Android Play submit pipeline

### Fix 1: Track name (`mobile/eas.json`)
- `submit.beta.android.track`: `"internal"` → `"CLOSED-BETA"`
- Matches the actual custom closed testing track configured in Google Play Console

### Fix 2: Archive source (`.github/workflows/mobile-ci.yml`)
- Added `--latest` flag to `eas submit` in the Mobile CI submit step
- Required for non-interactive mode to specify archive source

**Note:** `android-deploy.yml` already has the explicit `--id` approach from PR #22 — this fixes the separate submit path in `mobile-ci.yml`.

**Context:** Manual deploy of versionCode 26 to CLOSED-BETA is in progress. Once confirmed, merge this so future CI runs work automatically.