### PR TITLE
fix(sso): Sprint 3B — repair SSO first-time login profile creation

### DIFF
--- a/mobile/src/contexts/AuthContext.tsx
+++ b/mobile/src/contexts/AuthContext.tsx
@@ -182,8 +182,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       } catch (err: any) {
         // Only create a new profile if the backend returned 404 (profile doesn't exist yet)
         // Re-throw on network errors, 500s, or any other failure to avoid duplicate creation
-        const status = err?.response?.status ?? err?.statusCode;
-        if (status !== 404) {
+        const status = err?.statusCode ?? err?.response?.status;
+        const isNotFound = status === 404 || err?.message?.includes('not found');
+        if (!isNotFound) {
           throw err;
         }
         const profileData = await createUserProfile(token, {

--- a/mobile/src/services/authService.ts
+++ b/mobile/src/services/authService.ts
@@ -23,13 +23,14 @@ export const getUserProfile = async (token?: string): Promise<User> => {
     return response.data;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
-    console.error('Get profile error:', error.response?.data || error.message);
-    // Preserve the HTTP status so callers can distinguish 404 (not found) from other errors
+    console.error('Get profile error:', error.response?.data || error.responseData || error.message);
+    // Preserve the HTTP status so callers can distinguish 404 (not found) from other errors.
+    // Note: api.ts interceptor wraps errors — .response is stripped, but .statusCode is set.
     const err = new Error(
-      error.response?.data?.message || 'Failed to fetch user profile'
+      error.response?.data?.message || error.message || 'Failed to fetch user profile'
     ) as any;
-    err.response = error.response;
-    err.statusCode = error.response?.status;
+    err.statusCode = error.response?.status ?? error.statusCode;
+    err.responseData = error.response?.data ?? error.responseData;
     throw err;
   }
 };


### PR DESCRIPTION
## Sprint 3B Defect Fix — SSO First-Time Login

### Root Cause
The `api.ts` response interceptor wraps HTTP errors in new `Error` objects, stripping `.response` from the original Axios error. The error chain flows through 3 layers:

```
NestJS 404 → api.ts interceptor (strips .response, sets .statusCode) 
  → authService.ts getUserProfile (tried to read .response — undefined)
    → AuthContext.tsx handleSsoLogin (status check fails → re-throws instead of creating profile)
```

**Impact:** Every first-time Google/Apple SSO sign-in fails. The app can never create a profile for SSO users because `handleSsoLogin` can't detect the 404.

### Fix

**authService.ts:**
- Read `statusCode` from interceptor's enhanced error (`error.statusCode`) instead of the stripped `error.response.status`
- Also preserve `responseData` from interceptor's `error.responseData`

**AuthContext.tsx:**
- Check `err.statusCode` first (set by interceptor), `err.response?.status` as fallback
- Also match 'not found' in error message as defensive fallback

### Not in this PR (under investigation)

**Live events not loading:** Backend returns 200 + 114 events from prod API. The issue is frontend-side (possibly genreService Firestore query or rendering crash). Coordinating with Samantha.

**Profile update failure:** Backend `PUT /users/profile` with `UpdateUserDto` is correct. DTO fields match mobile service. May be related to the SSO login failure (can't update profile if profile was never created).

**Admin visibility:** Backend admin controller correctly gated with `@Roles(Role.ADMIN)`. Needs Firebase Auth custom claim verification.